### PR TITLE
Enable TypeScript strict mode

### DIFF
--- a/src/lib/_focusable-item.ts
+++ b/src/lib/_focusable-item.ts
@@ -18,7 +18,7 @@ export class FocusableItem {
   private element: HTMLElement;
   private focusState: boolean = false;
 
-  private neighbors: Neighbors;
+  private neighbors!: Neighbors;
 
   constructor(ele: HTMLElement) {
     this.element = ele;
@@ -46,7 +46,7 @@ export class FocusableItem {
     this.neighbors.top = index;
   };
 
-  getTopFocusItemIndex(): number {
+  getTopFocusItemIndex(): number|null {
     return this.neighbors.top;
   };
 
@@ -54,7 +54,7 @@ export class FocusableItem {
     this.neighbors.bottom = index;
   };
 
-  getBottomFocusItemIndex(): number {
+  getBottomFocusItemIndex(): number|null {
     return this.neighbors.bottom;
   };
 
@@ -62,7 +62,7 @@ export class FocusableItem {
     this.neighbors.left = index;
   };
 
-  getLeftFocusItemIndex(): number {
+  getLeftFocusItemIndex(): number|null {
     return this.neighbors.left;
   };
 
@@ -70,7 +70,7 @@ export class FocusableItem {
     this.neighbors.right = index;
   };
 
-  getRightFocusItemIndex(): number {
+  getRightFocusItemIndex(): number|null {
     return this.neighbors.right;
   };
 

--- a/src/lib/_focusable-item.ts
+++ b/src/lib/_focusable-item.ts
@@ -18,11 +18,11 @@ export class FocusableItem {
   private element: HTMLElement;
   private focusState: boolean = false;
 
-  private neighbors!: Neighbors;
+  private neighbors: Neighbors;
 
   constructor(ele: HTMLElement) {
     this.element = ele;
-    this.resetNeighbors();
+    this.neighbors = FocusableItem.defaultNeighbors();
   }
 
   getElement() {
@@ -34,13 +34,17 @@ export class FocusableItem {
   }
 
   resetNeighbors() {
-    this.neighbors = {
+    this.neighbors = FocusableItem.defaultNeighbors();
+  };
+
+  private static defaultNeighbors(): Neighbors {
+    return {
       top: null,
       bottom: null,
       left: null,
       right: null,
     };
-  };
+  }
 
   setTopFocusItemIndex(index: number) {
     this.neighbors.top = index;

--- a/src/lib/debug-controller.ts
+++ b/src/lib/debug-controller.ts
@@ -19,12 +19,12 @@ const MARKER_COLORS = [
 ];
 
 export class DebugController {
-  private dpad: DpadController;
+  private dpad: DpadController|null;
   private debugMode: boolean;
 
   constructor(dpad: DpadController|null) {
     if (!dpad) {
-      console.error(`Unable to debug since the dpad controller is not defined.`);    
+      console.error(`Unable to debug since the dpad controller is not defined.`);
     }
     this.dpad = dpad;
     this.debugMode = false;
@@ -43,7 +43,7 @@ export class DebugController {
   updateDisplay() {
     this.clearDisplay();
 
-    if (!this.debugMode) {
+    if (!this.debugMode || !this.dpad) {
       return
     }
 
@@ -74,7 +74,7 @@ export class DebugController {
 
     const topIndex = focusableItem.getTopFocusItemIndex();
     if(topIndex !== null) {
-      const topMetrics = this.dpad.getFocusableItem(topIndex).getMetrics();
+      const topMetrics = this.dpad!.getFocusableItem(topIndex)!.getMetrics();
       const xDist = topMetrics.center.x - currentItemMetrics.center.x;
       const yDist = currentItemMetrics.top - topMetrics.center.y;
 
@@ -85,7 +85,7 @@ export class DebugController {
 
     const bottomIndex = focusableItem.getBottomFocusItemIndex(); 
     if(bottomIndex !== null) {
-        const bottomMetrics = this.dpad.getFocusableItem(bottomIndex).getMetrics();
+        const bottomMetrics = this.dpad!.getFocusableItem(bottomIndex)!.getMetrics();
         const xDist = currentItemMetrics.center.x - bottomMetrics.center.x;
         const yDist = bottomMetrics.center.y - currentItemMetrics.bottom;
 
@@ -96,7 +96,7 @@ export class DebugController {
 
     const leftIndex = focusableItem.getLeftFocusItemIndex();
     if(leftIndex !== null) {
-        const leftMetrics = this.dpad.getFocusableItem(leftIndex).getMetrics();
+        const leftMetrics = this.dpad!.getFocusableItem(leftIndex)!.getMetrics();
         
         const xDist = leftMetrics.center.x - currentItemMetrics.left;
         const yDist = currentItemMetrics.center.y - leftMetrics.center.y;
@@ -108,7 +108,7 @@ export class DebugController {
 
     const rightIndex = focusableItem.getRightFocusItemIndex();
     if(rightIndex !== null) {
-      const rightMetrics = this.dpad.getFocusableItem(rightIndex).getMetrics();
+      const rightMetrics = this.dpad!.getFocusableItem(rightIndex)!.getMetrics();
       const xDist = rightMetrics.center.x - currentItemMetrics.right;
       const yDist = currentItemMetrics.center.y - rightMetrics.center.y;
 

--- a/src/lib/dpad-controller.ts
+++ b/src/lib/dpad-controller.ts
@@ -92,7 +92,7 @@ export class DpadController {
 
     // Need to reset currently focused item so that we can replace it
     // with the new FocusableItem in the focusableItems array
-    const previouslyFocusedItem: FocusableItem = this.currentlyFocusedItem;
+    const previouslyFocusedItem: FocusableItem|null = this.currentlyFocusedItem;
     this.currentlyFocusedItem = null;
 
     for(const fi of this.focusableItems) {
@@ -158,7 +158,7 @@ export class DpadController {
       var newItem = this.getFocusableItem(i);
       // If the element can't be focused, or is the current element,
       // skip it.
-      if(!newItem.isFocusable() || newItem === fi) {
+      if(!newItem || !newItem.isFocusable() || newItem === fi) {
           continue;
       }
 
@@ -259,7 +259,7 @@ export class DpadController {
     return this.horizontalDistance(fromMetrics, toMetrics, toMetrics, fromMetrics);
   }
 
-  private getRightDistance = function(fromMetrics: Metrics, toMetrics: Metrics) {
+  private getRightDistance = function(this: DpadController, fromMetrics: Metrics, toMetrics: Metrics) {
     // Move Right
     return this.horizontalDistance(fromMetrics, toMetrics, fromMetrics, toMetrics);
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,6 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
-    "strict": false
+    "strict": true
   }
 }


### PR DESCRIPTION
## Summary
- Flips `strict: true` (left explicitly off in #52) and fixes the type errors it surfaces:
  - `FocusableItem`'s neighbor getters were typed as returning non-nullable `number` even though the underlying `Neighbors` fields are `number|null` and reset to `null` on construction/reset.
  - `DpadController.update()`'s `previouslyFocusedItem` and `DebugController`'s `dpad` field were typed as non-nullable but can legitimately be `null`.
  - `updateNeighbors()` looked up a focusable item by index and called a method on it before checking it was non-null (never actually null in practice since the index is always in range, but not provable to the compiler, so the guard is added defensively).
  - `DebugController.updateDisplay()` now bails out early if `dpad` is null, fixing a latent crash if the display is toggled without a valid `DpadController` — the constructor already logged an error for this case but nothing stopped the subsequent null deref.
- No other behavior changes.

## Test plan
- [x] `npx tsc -p tsconfig.node-lib.json --noEmit` is clean
- [x] `npm run build` succeeds
- [x] Browser bundles still merge onto `window.gauntface.dpad` correctly