### PR TITLE
Normalize function-expression class fields to plain methods

### DIFF
--- a/src/lib/debug-controller.ts
+++ b/src/lib/debug-controller.ts
@@ -59,7 +59,7 @@ export class DebugController {
     }
   }
 
-  private clearDisplay = function() {
+  private clearDisplay() {
     const debugLines = document.querySelectorAll(DEBUG_LINE_SELECTOR);
     for(const dl of debugLines) {
       dl.remove();

--- a/src/lib/dpad-controller.ts
+++ b/src/lib/dpad-controller.ts
@@ -259,7 +259,7 @@ export class DpadController {
     return this.horizontalDistance(fromMetrics, toMetrics, toMetrics, fromMetrics);
   }
 
-  private getRightDistance = function(this: DpadController, fromMetrics: Metrics, toMetrics: Metrics) {
+  private getRightDistance(fromMetrics: Metrics, toMetrics: Metrics) {
     // Move Right
     return this.horizontalDistance(fromMetrics, toMetrics, fromMetrics, toMetrics);
   }


### PR DESCRIPTION
## Summary
`getRightDistance` and `clearDisplay` were declared as function-expression class fields while every sibling method uses normal method shorthand. No behavior change; also lets `getRightDistance` drop the explicit `this` parameter type that was only needed because of the function-expression form.

## Test plan
- [x] `npm run build` succeeds