### PR TITLE
Simplify dead try/catch in FocusableItem.isFocusable()

### DIFF
--- a/src/lib/_focusable-item.ts
+++ b/src/lib/_focusable-item.ts
@@ -83,19 +83,13 @@ export class FocusableItem {
       return false;
     }
 
-    let tabIndexAttr = this.element.getAttribute('tabindex');
+    const tabIndexAttr = this.element.getAttribute('tabindex');
     if (!tabIndexAttr) {
       return false
     }
-    
-    try {
-      const tabIndex = parseInt(tabIndexAttr, 10)
-      return tabIndex > -1;
-    } catch (err) {
-      // NOOP
-    }
 
-    return false;
+    const tabIndex = parseInt(tabIndexAttr, 10)
+    return tabIndex > -1;
   }
 
   getMetrics(): Metrics {


### PR DESCRIPTION
## Summary
`parseInt()` never throws, and `NaN > -1` is simply `false`, so the catch branch was unreachable dead code. No behavior change.

## Test plan
- [x] `npm run build` succeeds