### PR TITLE
Modernize event.keyCode to event.key

### DIFF
--- a/src/lib/dpad-controller.test.ts
+++ b/src/lib/dpad-controller.test.ts
@@ -207,3 +207,36 @@ describe('DpadController.moveFocus / update', () => {
     expect(document.activeElement).toBe(elements[5]);
   });
 });
+
+describe('DpadController key handling', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it.each([
+    ['ArrowRight', 5],
+    ['ArrowDown', 7],
+    ['ArrowLeft', 3],
+    ['ArrowUp', 1],
+  ])('moves focus on %s to the correct neighbor', (key, expectedIndex) => {
+    const elements = buildGrid();
+    const dpad = new DpadController();
+    dpad.update();
+    dpad.setCurrentFocusItem(4);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', {key}));
+
+    expect(document.activeElement).toBe(elements[expectedIndex]);
+  });
+
+  it('does not move focus on Tab', () => {
+    const elements = buildGrid();
+    const dpad = new DpadController();
+    dpad.update();
+    dpad.setCurrentFocusItem(4);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', {key: 'Tab'}));
+
+    expect(document.activeElement).toBe(elements[4]);
+  });
+});

--- a/src/lib/dpad-controller.ts
+++ b/src/lib/dpad-controller.ts
@@ -265,33 +265,27 @@ export class DpadController {
   }
 
   private onKeyDown(event: KeyboardEvent) {
-    switch(event.keyCode) {
-        case 9:
-            // Tab
+    switch(event.key) {
+        case 'Tab':
             break;
-        case 37:
-            // Left
+        case 'ArrowLeft':
             event.preventDefault();
             this.moveFocus({x: -1, y: 0});
             break;
-        case 38:
-            // Up
+        case 'ArrowUp':
             event.preventDefault();
             this.moveFocus({x: 0, y: 1});
             break;
-        case 39:
-            // Right
+        case 'ArrowRight':
             event.preventDefault();
             this.moveFocus({x: 1, y: 0});
             break;
-        case 40:
-            // Down
+        case 'ArrowDown':
             event.preventDefault();
             this.moveFocus({x: 0, y: -1});
             break;
-        case 13:
-        case 32:
-            // Enter
+        case 'Enter':
+        case ' ':
             event.preventDefault();
             if(this.currentlyFocusedItem) {
                 this.currentlyFocusedItem.onItemClickStateChange(true);
@@ -301,9 +295,8 @@ export class DpadController {
   }
 
   private onKeyUp(event: KeyboardEvent) {
-    switch(event.keyCode) {
-        case 13:
-            // Enter
+    switch(event.key) {
+        case 'Enter':
             event.preventDefault();
             if(this.currentlyFocusedItem) {
                 this.currentlyFocusedItem.onItemClickStateChange(false);


### PR DESCRIPTION
## Summary
- `event.keyCode` is deprecated (MDN); switches on `event.key` instead, which also makes the intent of each case self-documenting without needing the numeric-code comments.
- Same key set handled as before (Tab, arrow keys, Enter/Space) with no behavior change - done last, after the moveFocus/update tests landed, so any regression from the rewrite would be caught.
- Adds tests dispatching real `keydown` events to confirm the new key names route to the same neighbors as the equivalent `moveFocus()` calls.

## Test plan
- [x] `npm run lint` and `npm run test` pass