### PR TITLE
Add static HTML demo — SpatialExplorer

### DIFF
--- a/examples/static-html/README.md
+++ b/examples/static-html/README.md
@@ -1,0 +1,43 @@
+# Static HTML demo
+
+A four-screen "10-foot UI" demo — `SpatialExplorer`, a fictional streaming
+app — built with plain HTML/CSS/JS and wired up to the real
+`DpadController` / `DebugController` from this library (no framework, no
+build step).
+
+- `index.html` — home page with a hero and two horizontal shelves
+- `grid.html` — "Navigation Lab", an irregular 5-column grid (wide/tall/
+  spanning nodes) designed to stress-test the spatial nearest-neighbor logic
+- `lists.html` — a vertical categories list next to a vertical content list
+- `settings.html` — form controls (buttons, a switch, checkboxes) including
+  a "Show Focus Vectors" checkbox that toggles the library's own debug
+  overlay (`DebugController`)
+
+## Running it
+
+Any static file server works, e.g. from this directory:
+
+```sh
+npx serve .
+```
+
+Then open the printed URL and navigate with arrow keys (or an actual D-pad
+input device).
+
+## How it's wired
+
+`lib/dpad-controller.js` and `lib/debug-controller.js` are vendored copies
+of this repo's own `build/browser/*.js` output (see the root `README.md`'s
+"Using the library via CDN" section for the supported way to load them from
+a CDN once published — self-hosting like this is the alternative it
+documents). Regenerate them after making library changes with:
+
+```sh
+npm run build --prefix ../.. && cp ../../build/browser/{dpad-controller,debug-controller}.js lib/
+```
+
+`lib/app.js` is demo glue, not part of the library: it instantiates
+`DpadController`/`DebugController` once per page, sets initial focus on the
+element marked `data-dpad-initial-focus`, and drives the debug HUD panel in
+the corner. Every actual focus-navigation behavior — which element is "up",
+"down", "left", "right" of the current one — comes from the library itself.

--- a/examples/static-html/README.md
+++ b/examples/static-html/README.md
@@ -40,4 +40,5 @@ npm run build --prefix ../.. && cp ../../build/browser/{dpad-controller,debug-co
 `DpadController`/`DebugController` once per page, sets initial focus on the
 element marked `data-dpad-initial-focus`, and drives the debug HUD panel in
 the corner. Every actual focus-navigation behavior — which element is "up",
-"down", "left", "right" of the current one — comes from the library itself.
+"down", "left", "right" of the current one — comes from the library itself,
+as does Enter/Space activating whatever's currently focused (see [#67](https://github.com/gauntface/dpad-navigation/pull/67), which restored that after it regressed during the TypeScript rewrite).

--- a/examples/static-html/css/theme.css
+++ b/examples/static-html/css/theme.css
@@ -1,0 +1,275 @@
+:root {
+  --surface: #0b1326;
+  --surface-container-lowest: #060e20;
+  --surface-container-low: #131b2e;
+  --surface-container: #171f33;
+  --surface-container-high: #222a3d;
+  --surface-container-highest: #2d3449;
+  --surface-bright: #31394d;
+  --on-surface: #dae2fd;
+  --on-surface-variant: #c7c4d7;
+  --outline: #908fa0;
+  --outline-variant: #464554;
+  --primary: #c0c1ff;
+  --on-primary: #1000a9;
+  --secondary: #ddb7ff;
+  --tertiary: #2fd9f4;
+  --debug-vector: #10b981;
+  --focus-glow: rgba(99, 102, 241, 0.5);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--surface);
+  color: var(--on-surface);
+  font-family: 'Hanken Grotesk', system-ui, sans-serif;
+  overflow: hidden;
+}
+
+.mono {
+  font-family: 'JetBrains Mono', monospace;
+}
+
+/* Layout shell shared by every page */
+.app-shell {
+  display: flex;
+  height: 100vh;
+  width: 100vw;
+}
+
+.side-nav {
+  width: 88px;
+  flex: none;
+  background: rgba(23, 31, 51, 0.85);
+  backdrop-filter: blur(20px);
+  border-right: 1px solid var(--outline-variant);
+  display: flex;
+  flex-direction: column;
+  padding: 32px 0;
+  z-index: 50;
+  transition: width 0.25s ease;
+}
+
+.side-nav:hover {
+  width: 240px;
+}
+
+.side-nav .brand {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 0 24px;
+  margin-bottom: 48px;
+  color: var(--primary);
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.side-nav .brand .icon {
+  font-size: 28px;
+  flex: none;
+}
+
+.side-nav nav {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+}
+
+.side-nav .nav-item {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 24px;
+  border: none;
+  border-left: 4px solid transparent;
+  background: transparent;
+  color: var(--on-surface-variant);
+  font: inherit;
+  font-size: 16px;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-align: left;
+  width: 100%;
+}
+
+.side-nav .nav-item .icon {
+  flex: none;
+  font-size: 22px;
+}
+
+.side-nav .nav-item.active {
+  color: var(--primary);
+  border-left-color: var(--primary);
+  background: rgba(192, 193, 255, 0.08);
+}
+
+.side-nav .nav-item:hover {
+  color: var(--on-surface);
+  background: var(--surface-bright);
+}
+
+.side-nav .avatar {
+  margin: 0 24px;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--primary), var(--secondary));
+  flex: none;
+}
+
+.main {
+  flex: 1;
+  overflow-y: auto;
+  padding: 32px 64px 96px;
+  scroll-behavior: smooth;
+}
+
+.top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 0 40px;
+  position: sticky;
+  top: 0;
+  background: linear-gradient(to bottom, var(--surface) 60%, transparent);
+  z-index: 40;
+}
+
+.top-bar h1 {
+  font-size: 24px;
+  color: var(--primary);
+  margin: 0;
+}
+
+.top-bar-actions {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+
+.search-box {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--surface-container-high);
+  border: 1px solid var(--outline-variant);
+  border-radius: 999px;
+  padding: 10px 24px;
+  color: var(--on-surface-variant);
+}
+
+.icon-btn {
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  background: var(--surface-container);
+  border: 2px solid transparent;
+  color: var(--primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 20px;
+}
+
+.icon-btn.active {
+  border-color: var(--primary);
+  background: rgba(192, 193, 255, 0.15);
+}
+
+/* Focus behavior driven by the real dpad-nav library */
+.dpad-focusable {
+  outline: none !important;
+  transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.dpad-focusable:focus {
+  transform: scale(1.05);
+  z-index: 5;
+  position: relative;
+  border-color: var(--primary) !important;
+  box-shadow: 0 0 25px var(--focus-glow);
+}
+
+.list-focus:focus {
+  background: rgba(45, 52, 73, 0.6);
+}
+
+.list-focus {
+  position: relative;
+  border-left: 4px solid transparent;
+}
+
+.list-focus:focus {
+  border-left-color: var(--primary);
+}
+
+.glass-panel {
+  background: rgba(23, 31, 51, 0.75);
+  backdrop-filter: blur(20px);
+  border: 1px solid var(--outline-variant);
+}
+
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+.no-scrollbar {
+  scrollbar-width: none;
+}
+
+/* Debug HUD shown by the demo apps (not part of the library) */
+.debug-hud {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  z-index: 60;
+  padding: 20px 24px;
+  border-radius: 12px;
+  min-width: 260px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.debug-hud.visible {
+  opacity: 1;
+}
+
+.debug-hud .dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--debug-vector);
+  display: inline-block;
+  margin-right: 10px;
+  animation: pulse 1.6s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.debug-hud .row {
+  margin: 4px 0;
+  font-size: 14px;
+  color: var(--on-surface-variant);
+}
+
+.debug-hud .row b {
+  color: var(--primary);
+}
+
+/* d-pad debugger draws its own absolutely-positioned lines on <body>;
+   this just keeps them above everything else. */
+.dpad-debugger-line {
+  z-index: 999 !important;
+}

--- a/examples/static-html/css/theme.css
+++ b/examples/static-html/css/theme.css
@@ -51,10 +51,14 @@ body {
   flex-direction: column;
   padding: 32px 0;
   z-index: 50;
+  overflow: hidden;
   transition: width 0.25s ease;
 }
 
-.side-nav:hover {
+/* :focus-within expands the rail for keyboard/d-pad users tabbing into the
+   nav, same as :hover does for a mouse -- a d-pad remote has no hover. */
+.side-nav:hover,
+.side-nav:focus-within {
   width: 240px;
 }
 
@@ -65,8 +69,6 @@ body {
   padding: 0 24px;
   margin-bottom: 48px;
   color: var(--primary);
-  white-space: nowrap;
-  overflow: hidden;
 }
 
 .side-nav .brand .icon {
@@ -93,15 +95,29 @@ body {
   font: inherit;
   font-size: 16px;
   cursor: pointer;
-  white-space: nowrap;
-  overflow: hidden;
   text-align: left;
+  text-decoration: none;
   width: 100%;
+  box-sizing: border-box;
 }
 
 .side-nav .nav-item .icon {
   flex: none;
   font-size: 22px;
+}
+
+/* Labels fade in/out rather than relying on the collapsed rail width to
+   clip the text -- clipped partial text (e.g. "Ho" for "Home") reads as a
+   layout bug, not a collapsed state. */
+.side-nav .label {
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.side-nav:hover .label,
+.side-nav:focus-within .label {
+  opacity: 1;
 }
 
 .side-nav .nav-item.active {
@@ -196,6 +212,20 @@ body {
   position: relative;
   border-color: var(--primary) !important;
   box-shadow: 0 0 25px var(--focus-glow);
+}
+
+/* Universal "something happened" feedback on activation (Enter/Space or a
+   real click) -- several focusable elements in this demo (Play Now, the
+   trending/library cards) are decorative and have no click handler of
+   their own, so without this a correctly-firing activation looks
+   identical to a broken one. */
+@keyframes dpad-activate-pulse {
+  from { box-shadow: 0 0 0 0 var(--focus-glow); }
+  to { box-shadow: 0 0 0 18px rgba(99, 102, 241, 0); }
+}
+
+.dpad-focusable.dpad-activated {
+  animation: dpad-activate-pulse 0.5s ease-out;
 }
 
 .list-focus:focus {

--- a/examples/static-html/grid.html
+++ b/examples/static-html/grid.html
@@ -97,16 +97,16 @@
       <span class="label">Spatial Demo</span>
     </div>
     <nav>
-      <a class="nav-item" href="index.html">
+      <a class="dpad-focusable nav-item" href="index.html" tabindex="0" data-node-id="nav-home">
         <span class="material-symbols-outlined icon">home</span><span class="label">Home</span>
       </a>
-      <button class="dpad-focusable nav-item active" tabindex="1">
+      <button class="dpad-focusable nav-item active" tabindex="0" data-node-id="nav-grid">
         <span class="material-symbols-outlined icon">grid_view</span><span class="label">Grid Demo</span>
       </button>
-      <a class="nav-item" href="lists.html">
+      <a class="dpad-focusable nav-item" href="lists.html" tabindex="0" data-node-id="nav-lists">
         <span class="material-symbols-outlined icon">list</span><span class="label">Lists</span>
       </a>
-      <a class="nav-item" href="settings.html">
+      <a class="dpad-focusable nav-item" href="settings.html" tabindex="0" data-node-id="nav-settings">
         <span class="material-symbols-outlined icon">settings</span><span class="label">Settings</span>
       </a>
     </nav>

--- a/examples/static-html/grid.html
+++ b/examples/static-html/grid.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Navigation Lab — dpad-nav demo</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700;800&family=JetBrains+Mono:wght@500;700&display=swap" />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
+<link rel="stylesheet" href="css/theme.css" />
+<style>
+  .page-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 40px;
+  }
+  .page-head h2 {
+    font-size: 40px;
+    margin: 0 0 8px;
+    color: var(--primary);
+  }
+  .page-head p {
+    color: var(--on-surface-variant);
+    margin: 0;
+  }
+  .debug-toggle-btn {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 24px;
+    border-radius: 999px;
+    border: none;
+    background: linear-gradient(90deg, #7b2ff7, #6f00be);
+    color: white;
+    font-family: 'JetBrains Mono', monospace;
+    font-weight: 700;
+    font-size: 14px;
+    cursor: pointer;
+  }
+  .lab-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 24px;
+  }
+  .node {
+    border: 1px solid var(--outline-variant);
+    background: var(--surface-container);
+    border-radius: 12px;
+    padding: 20px;
+    display: flex;
+    align-items: flex-end;
+    min-height: 160px;
+    font-size: 20px;
+    font-weight: 700;
+  }
+  .node.feature {
+    grid-column: span 3;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-end;
+    background: linear-gradient(135deg, #1b2a4a, #0b1326);
+  }
+  .node.feature p {
+    font-size: 14px;
+    font-weight: 400;
+    color: var(--on-surface-variant);
+    margin: 8px 0 0;
+  }
+  .node.wide {
+    grid-column: span 2;
+    background: linear-gradient(135deg, #101d3d, #0b1326);
+  }
+  .node.footer {
+    grid-column: span 4;
+    background: linear-gradient(135deg, #0e1830, #0b1326);
+  }
+  .lab-status {
+    margin-top: 40px;
+    padding-top: 24px;
+    border-top: 1px solid var(--outline-variant);
+    display: flex;
+    gap: 48px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 14px;
+    color: var(--on-surface-variant);
+  }
+  .lab-status b {
+    color: var(--tertiary);
+  }
+</style>
+</head>
+<body>
+<div class="app-shell">
+  <aside class="side-nav">
+    <div class="brand">
+      <span class="material-symbols-outlined icon">spatial_audio_off</span>
+      <span>Spatial Demo</span>
+    </div>
+    <nav>
+      <a class="nav-item" href="index.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
+        <span class="material-symbols-outlined icon">home</span><span>Home</span>
+      </a>
+      <button class="dpad-focusable nav-item active" tabindex="1">
+        <span class="material-symbols-outlined icon">grid_view</span><span>Grid Demo</span>
+      </button>
+      <a class="nav-item" href="lists.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
+        <span class="material-symbols-outlined icon">list</span><span>Lists</span>
+      </a>
+      <a class="nav-item" href="settings.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
+        <span class="material-symbols-outlined icon">settings</span><span>Settings</span>
+      </a>
+    </nav>
+    <div class="avatar"></div>
+  </aside>
+
+  <main class="main no-scrollbar">
+    <div class="page-head">
+      <div>
+        <h2>Navigation Lab</h2>
+        <p>Complex 5-column spatial traversal testing — irregular spans force the library's nearest-neighbor logic, not simple grid-index math.</p>
+      </div>
+      <button class="debug-toggle-btn" data-dpad-debug-toggle="button" data-node-id="debug-toggle">
+        <span class="material-symbols-outlined" style="font-size: 18px;">bug_report</span>
+        Debug Mode: <span data-dpad-debug-label>OFF</span>
+      </button>
+    </div>
+
+    <div class="lab-grid">
+      <div class="dpad-focusable node" tabindex="10" data-node-id="node-01" data-dpad-initial-focus>01</div>
+      <div class="dpad-focusable node wide" tabindex="11" data-node-id="node-02">02 — Wide Node</div>
+      <div class="dpad-focusable node" tabindex="12" data-node-id="node-03">03</div>
+      <div class="dpad-focusable node" tabindex="13" data-node-id="node-04">04</div>
+
+      <div class="dpad-focusable node" tabindex="20" data-node-id="node-05">05</div>
+      <div class="dpad-focusable node" tabindex="21" data-node-id="node-06">06</div>
+      <div class="dpad-focusable node" tabindex="22" data-node-id="node-07">07</div>
+      <div class="dpad-focusable node" tabindex="23" data-node-id="node-08">08</div>
+      <div class="dpad-focusable node" tabindex="24" data-node-id="node-09">09</div>
+
+      <div class="dpad-focusable node feature" tabindex="30" data-node-id="node-feature">
+        Feature Node — Path Test
+        <p>Spanning 3 columns forces unique up/down logic across the items above and below.</p>
+      </div>
+      <div class="dpad-focusable node" tabindex="31" data-node-id="node-10">10</div>
+      <div class="dpad-focusable node" tabindex="32" data-node-id="node-11">11</div>
+
+      <div class="dpad-focusable node" tabindex="40" data-node-id="node-12">12</div>
+      <div class="dpad-focusable node footer" tabindex="41" data-node-id="node-13">13 — Massive Footer Node</div>
+    </div>
+
+    <div class="lab-status">
+      <span>Focus Count: <b>14 Nodes</b></span>
+      <span>Grid Layout: <b>5-Column Responsive</b></span>
+      <span>Current Pos: <b data-current-pos>node-01</b></span>
+    </div>
+  </main>
+</div>
+
+<div class="debug-hud glass-panel mono" id="debug-hud">
+  <div><span class="dot"></span><b>SPATIAL NODE ACTIVE</b></div>
+  <div class="row">ID: <b id="debug-hud-id">none</b></div>
+  <div class="row">TABINDEX: <b id="debug-hud-tabindex">0</b></div>
+  <div class="row">COORDS: <b id="debug-hud-coords">0, 0</b></div>
+</div>
+
+<script src="lib/dpad-controller.js"></script>
+<script src="lib/debug-controller.js"></script>
+<script src="lib/app.js"></script>
+</body>
+</html>

--- a/examples/static-html/grid.html
+++ b/examples/static-html/grid.html
@@ -94,20 +94,20 @@
   <aside class="side-nav">
     <div class="brand">
       <span class="material-symbols-outlined icon">spatial_audio_off</span>
-      <span>Spatial Demo</span>
+      <span class="label">Spatial Demo</span>
     </div>
     <nav>
-      <a class="nav-item" href="index.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
-        <span class="material-symbols-outlined icon">home</span><span>Home</span>
+      <a class="nav-item" href="index.html">
+        <span class="material-symbols-outlined icon">home</span><span class="label">Home</span>
       </a>
       <button class="dpad-focusable nav-item active" tabindex="1">
-        <span class="material-symbols-outlined icon">grid_view</span><span>Grid Demo</span>
+        <span class="material-symbols-outlined icon">grid_view</span><span class="label">Grid Demo</span>
       </button>
-      <a class="nav-item" href="lists.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
-        <span class="material-symbols-outlined icon">list</span><span>Lists</span>
+      <a class="nav-item" href="lists.html">
+        <span class="material-symbols-outlined icon">list</span><span class="label">Lists</span>
       </a>
-      <a class="nav-item" href="settings.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
-        <span class="material-symbols-outlined icon">settings</span><span>Settings</span>
+      <a class="nav-item" href="settings.html">
+        <span class="material-symbols-outlined icon">settings</span><span class="label">Settings</span>
       </a>
     </nav>
     <div class="avatar"></div>
@@ -119,7 +119,7 @@
         <h2>Navigation Lab</h2>
         <p>Complex 5-column spatial traversal testing — irregular spans force the library's nearest-neighbor logic, not simple grid-index math.</p>
       </div>
-      <button class="debug-toggle-btn" data-dpad-debug-toggle="button" data-node-id="debug-toggle">
+      <button class="dpad-focusable debug-toggle-btn" tabindex="0" data-dpad-debug-toggle="button" data-node-id="debug-toggle">
         <span class="material-symbols-outlined" style="font-size: 18px;">bug_report</span>
         Debug Mode: <span data-dpad-debug-label>OFF</span>
       </button>

--- a/examples/static-html/index.html
+++ b/examples/static-html/index.html
@@ -105,20 +105,20 @@
   <aside class="side-nav">
     <div class="brand">
       <span class="material-symbols-outlined icon">spatial_audio_off</span>
-      <span>Spatial Demo</span>
+      <span class="label">Spatial Demo</span>
     </div>
     <nav>
       <button class="dpad-focusable nav-item active" tabindex="1">
-        <span class="material-symbols-outlined icon">home</span><span>Home</span>
+        <span class="material-symbols-outlined icon">home</span><span class="label">Home</span>
       </button>
-      <a class="nav-item" href="grid.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
-        <span class="material-symbols-outlined icon">grid_view</span><span>Grid Demo</span>
+      <a class="nav-item" href="grid.html">
+        <span class="material-symbols-outlined icon">grid_view</span><span class="label">Grid Demo</span>
       </a>
-      <a class="nav-item" href="lists.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
-        <span class="material-symbols-outlined icon">list</span><span>Lists</span>
+      <a class="nav-item" href="lists.html">
+        <span class="material-symbols-outlined icon">list</span><span class="label">Lists</span>
       </a>
-      <a class="nav-item" href="settings.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
-        <span class="material-symbols-outlined icon">settings</span><span>Settings</span>
+      <a class="nav-item" href="settings.html">
+        <span class="material-symbols-outlined icon">settings</span><span class="label">Settings</span>
       </a>
     </nav>
     <div class="avatar"></div>

--- a/examples/static-html/index.html
+++ b/examples/static-html/index.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>SpatialExplorer — dpad-nav demo</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700;800&family=JetBrains+Mono:wght@500;700&display=swap" />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
+<link rel="stylesheet" href="css/theme.css" />
+<style>
+  .hero {
+    padding: 40px 0 80px;
+    max-width: 640px;
+  }
+  .hero .eyebrow {
+    font-family: 'JetBrains Mono', monospace;
+    letter-spacing: 0.2em;
+    color: var(--secondary);
+    font-size: 14px;
+  }
+  .hero h2 {
+    font-size: 56px;
+    line-height: 1.1;
+    margin: 16px 0 24px;
+  }
+  .hero p {
+    color: var(--on-surface-variant);
+    font-size: 18px;
+    line-height: 1.6;
+    margin-bottom: 32px;
+  }
+  .hero-actions {
+    display: flex;
+    gap: 20px;
+  }
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 16px 32px;
+    border-radius: 12px;
+    border: 1px solid transparent;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
+    font-family: inherit;
+  }
+  .btn-primary {
+    background: var(--primary);
+    color: var(--on-primary);
+  }
+  .btn-secondary {
+    background: rgba(45, 52, 73, 0.6);
+    color: var(--on-surface);
+    border-color: var(--outline-variant);
+  }
+  .shelf {
+    margin-bottom: 56px;
+  }
+  .shelf-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 20px;
+  }
+  .shelf-head h3 {
+    font-size: 24px;
+    margin: 0;
+  }
+  .shelf-head span {
+    color: var(--secondary);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 14px;
+  }
+  .rail {
+    display: flex;
+    gap: 24px;
+    overflow-x: auto;
+    padding: 8px 4px 16px;
+  }
+  .card {
+    flex: none;
+    border-radius: 14px;
+    border: 2px solid transparent;
+    overflow: hidden;
+    position: relative;
+    display: flex;
+    align-items: flex-end;
+    padding: 16px;
+    font-weight: 700;
+    color: white;
+  }
+  .card.wide {
+    width: 320px;
+    aspect-ratio: 16 / 9;
+  }
+  .card.tall {
+    width: 200px;
+    aspect-ratio: 2 / 3;
+  }
+</style>
+</head>
+<body>
+<div class="app-shell">
+  <aside class="side-nav">
+    <div class="brand">
+      <span class="material-symbols-outlined icon">spatial_audio_off</span>
+      <span>Spatial Demo</span>
+    </div>
+    <nav>
+      <button class="dpad-focusable nav-item active" tabindex="1">
+        <span class="material-symbols-outlined icon">home</span><span>Home</span>
+      </button>
+      <a class="nav-item" href="grid.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
+        <span class="material-symbols-outlined icon">grid_view</span><span>Grid Demo</span>
+      </a>
+      <a class="nav-item" href="lists.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
+        <span class="material-symbols-outlined icon">list</span><span>Lists</span>
+      </a>
+      <a class="nav-item" href="settings.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
+        <span class="material-symbols-outlined icon">settings</span><span>Settings</span>
+      </a>
+    </nav>
+    <div class="avatar"></div>
+  </aside>
+
+  <main class="main no-scrollbar">
+    <header class="top-bar">
+      <h1>SpatialExplorer</h1>
+      <div class="top-bar-actions">
+        <div class="search-box">
+          <span class="material-symbols-outlined">search</span>
+          <span>Search...</span>
+        </div>
+        <button class="dpad-focusable icon-btn" tabindex="2" data-dpad-debug-toggle="icon" title="Toggle debug vectors">
+          <span class="material-symbols-outlined">bug_report</span>
+        </button>
+        <button class="dpad-focusable icon-btn" tabindex="3">
+          <span class="material-symbols-outlined">account_circle</span>
+        </button>
+      </div>
+    </header>
+
+    <section class="hero">
+      <div class="eyebrow">ORIGINAL SERIES</div>
+      <h2>THE NEON<br />CHRONICLES</h2>
+      <p>In a world where memories are traded like currency, one rogue navigator must find the source code of reality before the system reboots.</p>
+      <div class="hero-actions">
+        <button class="dpad-focusable btn btn-primary" tabindex="4" data-dpad-initial-focus data-node-id="play-now">
+          <span class="material-symbols-outlined">play_arrow</span>Play Now
+        </button>
+        <button class="dpad-focusable btn btn-secondary" tabindex="5" data-node-id="more-info">
+          <span class="material-symbols-outlined">info</span>More Info
+        </button>
+      </div>
+    </section>
+
+    <section class="shelf">
+      <div class="shelf-head">
+        <h3>Trending Now</h3>
+        <span>View All</span>
+      </div>
+      <div class="rail no-scrollbar">
+        <div class="dpad-focusable card wide" tabindex="6" data-node-id="signal-lost" style="background: linear-gradient(135deg, #1b2a4a, #0b1326);">Signal Lost</div>
+        <div class="dpad-focusable card wide" tabindex="7" data-node-id="velocity-noir" style="background: linear-gradient(135deg, #3a1b4a, #0b1326);">Velocity Noir</div>
+        <div class="dpad-focusable card wide" tabindex="8" data-node-id="eden-404" style="background: linear-gradient(135deg, #0f4a3a, #0b1326);">Eden 404</div>
+        <div class="dpad-focusable card wide" tabindex="9" data-node-id="protocol-7" style="background: linear-gradient(135deg, #4a1b2e, #0b1326);">Protocol 7</div>
+      </div>
+    </section>
+
+    <section class="shelf">
+      <div class="shelf-head">
+        <h3>Your Library</h3>
+        <span>Sort by Recent</span>
+      </div>
+      <div class="rail no-scrollbar">
+        <div class="dpad-focusable card tall" tabindex="10" data-node-id="orbital" style="background: linear-gradient(160deg, #2a2450, #0b1326);">Orbital</div>
+        <div class="dpad-focusable card tall" tabindex="11" data-node-id="synthesis" style="background: linear-gradient(160deg, #4a3a1b, #0b1326);">Synthesis</div>
+        <div class="dpad-focusable card tall" tabindex="12" data-node-id="retroglow" style="background: linear-gradient(160deg, #4a1b45, #0b1326);">Retroglow</div>
+        <div class="dpad-focusable card tall" tabindex="13" data-node-id="monolith" style="background: linear-gradient(160deg, #33394a, #0b1326);">Monolith</div>
+        <div class="dpad-focusable card tall" tabindex="14" data-node-id="flux" style="background: linear-gradient(160deg, #1b3a4a, #0b1326);">Flux</div>
+      </div>
+    </section>
+  </main>
+</div>
+
+<div class="debug-hud glass-panel mono" id="debug-hud">
+  <div><span class="dot"></span><b>SPATIAL NODE ACTIVE</b></div>
+  <div class="row">ID: <b id="debug-hud-id">none</b></div>
+  <div class="row">TABINDEX: <b id="debug-hud-tabindex">0</b></div>
+  <div class="row">COORDS: <b id="debug-hud-coords">0, 0</b></div>
+</div>
+
+<script src="lib/dpad-controller.js"></script>
+<script src="lib/debug-controller.js"></script>
+<script src="lib/app.js"></script>
+</body>
+</html>

--- a/examples/static-html/index.html
+++ b/examples/static-html/index.html
@@ -108,16 +108,16 @@
       <span class="label">Spatial Demo</span>
     </div>
     <nav>
-      <button class="dpad-focusable nav-item active" tabindex="1">
+      <button class="dpad-focusable nav-item active" tabindex="0" data-node-id="nav-home">
         <span class="material-symbols-outlined icon">home</span><span class="label">Home</span>
       </button>
-      <a class="nav-item" href="grid.html">
+      <a class="dpad-focusable nav-item" href="grid.html" tabindex="0" data-node-id="nav-grid">
         <span class="material-symbols-outlined icon">grid_view</span><span class="label">Grid Demo</span>
       </a>
-      <a class="nav-item" href="lists.html">
+      <a class="dpad-focusable nav-item" href="lists.html" tabindex="0" data-node-id="nav-lists">
         <span class="material-symbols-outlined icon">list</span><span class="label">Lists</span>
       </a>
-      <a class="nav-item" href="settings.html">
+      <a class="dpad-focusable nav-item" href="settings.html" tabindex="0" data-node-id="nav-settings">
         <span class="material-symbols-outlined icon">settings</span><span class="label">Settings</span>
       </a>
     </nav>

--- a/examples/static-html/index.html
+++ b/examples/static-html/index.html
@@ -76,7 +76,15 @@
     display: flex;
     gap: 24px;
     overflow-x: auto;
-    padding: 8px 4px 16px;
+    /* The focused card scales up (transform: scale(1.05)) and grows a
+       25px glow (box-shadow); overflow-x: auto clips both at this
+       container's edge, so the first/last card looked "clipped" when
+       focused. Give the scroll box 40px of padding on every side as
+       breathing room, then pull it back with a matching negative
+       margin so the rail's resting-state alignment with its heading
+       above is unaffected. */
+    margin: 0 -40px;
+    padding: 24px 40px;
   }
   .card {
     flex: none;

--- a/examples/static-html/lib/app.js
+++ b/examples/static-html/lib/app.js
@@ -26,6 +26,18 @@
   const hudCoords = document.getElementById('debug-hud-coords');
 
   document.querySelectorAll('.dpad-focusable').forEach((el) => {
+    // Several elements here (Play Now, the trending/library cards) are
+    // decorative and have no click handler of their own -- without this,
+    // a correctly-firing Enter/Space activation (see #67) looks identical
+    // to a broken one, since nothing else visibly reacts.
+    el.addEventListener('click', () => {
+      el.classList.remove('dpad-activated');
+      // Force a reflow so re-adding the class restarts the animation if
+      // it's pressed again before the previous pulse finished.
+      void el.offsetWidth;
+      el.classList.add('dpad-activated');
+    });
+
     el.addEventListener('focus', () => {
       if (!hud) return;
       const rect = el.getBoundingClientRect();

--- a/examples/static-html/lib/app.js
+++ b/examples/static-html/lib/app.js
@@ -11,19 +11,6 @@
 
   window.dpadNavDemo = {dpad, debug};
 
-  // DpadController.onKeyDown preventDefaults Enter/Space and routes to
-  // FocusableItem#onItemClickStateChange, which is a no-op unless you
-  // supply your own FocusableItem subclass -- so out of the box, a focused
-  // .dpad-focusable element does NOT activate on Enter the way native
-  // browser focus normally would. Restore that expectation generically.
-  document.addEventListener('keyup', (event) => {
-    if (event.key !== 'Enter' && event.key !== ' ') return;
-    const el = document.activeElement;
-    if (el instanceof HTMLElement && el.classList.contains('dpad-focusable')) {
-      el.click();
-    }
-  });
-
   const initial = document.querySelector('[data-dpad-initial-focus]');
   if (initial) {
     const items = dpad.getFocusableItems();

--- a/examples/static-html/lib/app.js
+++ b/examples/static-html/lib/app.js
@@ -11,6 +11,19 @@
 
   window.dpadNavDemo = {dpad, debug};
 
+  // DpadController.onKeyDown preventDefaults Enter/Space and routes to
+  // FocusableItem#onItemClickStateChange, which is a no-op unless you
+  // supply your own FocusableItem subclass -- so out of the box, a focused
+  // .dpad-focusable element does NOT activate on Enter the way native
+  // browser focus normally would. Restore that expectation generically.
+  document.addEventListener('keyup', (event) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    const el = document.activeElement;
+    if (el instanceof HTMLElement && el.classList.contains('dpad-focusable')) {
+      el.click();
+    }
+  });
+
   const initial = document.querySelector('[data-dpad-initial-focus]');
   if (initial) {
     const items = dpad.getFocusableItems();
@@ -57,8 +70,9 @@
   const syncDebugToggles = () => {
     debugToggleEls.forEach((btn) => {
       btn.classList.toggle('active', debugOn);
-      if (btn.dataset.dpadDebugToggle === 'checkbox') {
-        btn.checked = debugOn;
+      const box = btn.querySelector('.checkbox-box');
+      if (box) {
+        box.classList.toggle('checked', debugOn);
       }
     });
     const label = document.querySelector('[data-dpad-debug-label]');

--- a/examples/static-html/lib/app.js
+++ b/examples/static-html/lib/app.js
@@ -1,0 +1,84 @@
+// Wires up the real @gauntface/dpad-nav library (vendored in ./lib/ from
+// this repo's own build/browser output -- see lib/README.md) against
+// whatever `.dpad-focusable[tabindex]` elements exist on the page, plus a
+// small debug HUD that isn't part of the library itself.
+(function () {
+  const {DpadController, DebugController} = window.gauntface.dpad;
+
+  const dpad = new DpadController();
+  const debug = new DebugController(dpad);
+  dpad.update();
+
+  window.dpadNavDemo = {dpad, debug};
+
+  const initial = document.querySelector('[data-dpad-initial-focus]');
+  if (initial) {
+    const items = dpad.getFocusableItems();
+    const index = items.findIndex((item) => item.getElement() === initial);
+    if (index > -1) {
+      dpad.setCurrentFocusItem(index);
+    }
+  }
+
+  const hud = document.getElementById('debug-hud');
+  const hudId = document.getElementById('debug-hud-id');
+  const hudTabindex = document.getElementById('debug-hud-tabindex');
+  const hudCoords = document.getElementById('debug-hud-coords');
+
+  document.querySelectorAll('.dpad-focusable').forEach((el) => {
+    el.addEventListener('focus', () => {
+      if (!hud) return;
+      const rect = el.getBoundingClientRect();
+      hud.classList.add('visible');
+      hudId.textContent = el.dataset.nodeId || el.tagName.toLowerCase();
+      hudTabindex.textContent = el.tabIndex;
+      hudCoords.textContent = `${Math.round(rect.x)}, ${Math.round(rect.y)}`;
+
+      const rail = el.closest('.rail');
+      if (rail) {
+        const railRect = rail.getBoundingClientRect();
+        const elRect = el.getBoundingClientRect();
+        if (elRect.right > railRect.right - 80) {
+          rail.scrollBy({left: 320, behavior: 'smooth'});
+        } else if (elRect.left < railRect.left + 80) {
+          rail.scrollBy({left: -320, behavior: 'smooth'});
+        }
+      }
+
+      const currentPos = document.querySelector('[data-current-pos]');
+      if (currentPos) {
+        currentPos.textContent = el.dataset.nodeId || `tabindex ${el.tabIndex}`;
+      }
+    });
+  });
+
+  let debugOn = false;
+  const debugToggleEls = document.querySelectorAll('[data-dpad-debug-toggle]');
+  const syncDebugToggles = () => {
+    debugToggleEls.forEach((btn) => {
+      btn.classList.toggle('active', debugOn);
+      if (btn.dataset.dpadDebugToggle === 'checkbox') {
+        btn.checked = debugOn;
+      }
+    });
+    const label = document.querySelector('[data-dpad-debug-label]');
+    if (label) {
+      label.textContent = debugOn ? 'ON' : 'OFF';
+    }
+  };
+  debugToggleEls.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      debug.toggleDebugMode();
+      debugOn = !debugOn;
+      syncDebugToggles();
+    });
+  });
+  syncDebugToggles();
+
+  document.querySelectorAll('[data-dpad-reset]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      dpad.update();
+      dpad.setCurrentFocusItem(0);
+    });
+  });
+})();

--- a/examples/static-html/lib/debug-controller.js
+++ b/examples/static-html/lib/debug-controller.js
@@ -1,0 +1,138 @@
+var __dpadBundleExports = (() => {
+  var __defProp = Object.defineProperty;
+  var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+  var __getOwnPropNames = Object.getOwnPropertyNames;
+  var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __export = (target, all) => {
+    for (var name in all)
+      __defProp(target, name, { get: all[name], enumerable: true });
+  };
+  var __copyProps = (to, from, except, desc) => {
+    if (from && typeof from === "object" || typeof from === "function") {
+      for (let key of __getOwnPropNames(from))
+        if (!__hasOwnProp.call(to, key) && key !== except)
+          __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+    }
+    return to;
+  };
+  var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+  // src/lib/debug-controller.ts
+  var debug_controller_exports = {};
+  __export(debug_controller_exports, {
+    DebugController: () => DebugController
+  });
+
+  // src/lib/_calc-distance.ts
+  function calcDistance(x, y) {
+    return Math.floor(Math.sqrt(x * x + y * y));
+  }
+
+  // src/lib/debug-controller.ts
+  var DBEUG_LINE_CLASSNAME = "dpad-debugger-line";
+  var DEBUG_LINE_SELECTOR = `.${DBEUG_LINE_CLASSNAME}`;
+  var MARKER_COLORS = [
+    "#1abc9c",
+    "#2ecc71",
+    "#3498db",
+    "#9b59b6",
+    "#34495e",
+    "#f1c40f",
+    "#e67e22",
+    "#e74c3c",
+    "#ecf0f1",
+    "#95a5a6"
+  ];
+  var DebugController = class {
+    constructor(dpad) {
+      this.clearDisplay = function() {
+        const debugLines = document.querySelectorAll(DEBUG_LINE_SELECTOR);
+        for (const dl of debugLines) {
+          dl.remove();
+        }
+      };
+      if (!dpad) {
+        console.error(`Unable to debug since the dpad controller is not defined.`);
+      }
+      this.dpad = dpad;
+      this.debugMode = false;
+    }
+    setDebugMode(d) {
+      this.debugMode = d;
+      this.updateDisplay();
+    }
+    toggleDebugMode() {
+      this.debugMode = !this.debugMode;
+      this.updateDisplay();
+    }
+    updateDisplay() {
+      this.clearDisplay();
+      if (!this.debugMode) {
+        return;
+      }
+      const items = this.dpad.getFocusableItems();
+      for (let i = 0; i < items.length; i++) {
+        const fi = items[i];
+        if (!fi.isFocusable()) {
+          continue;
+        }
+        this.printDebugLinesForItem(i, fi);
+      }
+    }
+    printDebugLinesForItem(index, focusableItem) {
+      const markerIndex = index % MARKER_COLORS.length;
+      const markerColor = MARKER_COLORS[markerIndex];
+      const currentItemMetrics = focusableItem.getMetrics();
+      const topIndex = focusableItem.getTopFocusItemIndex();
+      if (topIndex !== null) {
+        const topMetrics = this.dpad.getFocusableItem(topIndex).getMetrics();
+        const xDist = topMetrics.center.x - currentItemMetrics.center.x;
+        const yDist = currentItemMetrics.top - topMetrics.center.y;
+        const angle = Math.atan2(xDist, yDist) * 180 / Math.PI + 180;
+        this.printDebugLine(calcDistance(xDist, yDist), currentItemMetrics.center.x - 5, currentItemMetrics.top, markerColor, angle);
+      }
+      const bottomIndex = focusableItem.getBottomFocusItemIndex();
+      if (bottomIndex !== null) {
+        const bottomMetrics = this.dpad.getFocusableItem(bottomIndex).getMetrics();
+        const xDist = currentItemMetrics.center.x - bottomMetrics.center.x;
+        const yDist = bottomMetrics.center.y - currentItemMetrics.bottom;
+        const angle = Math.atan2(xDist, yDist) * 180 / Math.PI + 360;
+        this.printDebugLine(calcDistance(xDist, yDist), currentItemMetrics.center.x + 5, currentItemMetrics.bottom, markerColor, angle);
+      }
+      const leftIndex = focusableItem.getLeftFocusItemIndex();
+      if (leftIndex !== null) {
+        const leftMetrics = this.dpad.getFocusableItem(leftIndex).getMetrics();
+        const xDist = leftMetrics.center.x - currentItemMetrics.left;
+        const yDist = currentItemMetrics.center.y - leftMetrics.center.y;
+        const angle = Math.atan2(xDist, yDist) * 180 / Math.PI + 180;
+        this.printDebugLine(calcDistance(xDist, yDist), currentItemMetrics.left, currentItemMetrics.center.y + 5, markerColor, angle);
+      }
+      const rightIndex = focusableItem.getRightFocusItemIndex();
+      if (rightIndex !== null) {
+        const rightMetrics = this.dpad.getFocusableItem(rightIndex).getMetrics();
+        const xDist = rightMetrics.center.x - currentItemMetrics.right;
+        const yDist = currentItemMetrics.center.y - rightMetrics.center.y;
+        const angle = Math.atan2(xDist, yDist) * 180 / Math.PI + 180;
+        this.printDebugLine(calcDistance(xDist, yDist), currentItemMetrics.right, currentItemMetrics.center.y - 5, markerColor, angle);
+      }
+    }
+    printDebugLine(length, startX, startY, color, angle) {
+      const lineElement = document.createElement("div");
+      lineElement.classList.add(DBEUG_LINE_CLASSNAME);
+      lineElement.classList.add("marker");
+      lineElement.classList.add("start");
+      lineElement.style.position = "absolute";
+      lineElement.style.width = "5px";
+      lineElement.style.height = length + "px";
+      lineElement.style.left = startX + "px";
+      lineElement.style.top = startY + "px";
+      lineElement.style.backgroundColor = color;
+      lineElement.style.transform = "rotate(" + angle + "deg)";
+      lineElement.style.transformOrigin = "0% 0%";
+      document.body.appendChild(lineElement);
+    }
+  };
+  return __toCommonJS(debug_controller_exports);
+})();
+window.gauntface = window.gauntface || {};
+window.gauntface.dpad = Object.assign(window.gauntface.dpad || {}, __dpadBundleExports);

--- a/examples/static-html/lib/dpad-controller.js
+++ b/examples/static-html/lib/dpad-controller.js
@@ -99,6 +99,9 @@ var __dpadBundleExports = (() => {
       };
     }
     onItemClickStateChange(isDown) {
+      if (!isDown) {
+        this.element.click();
+      }
     }
   };
 
@@ -318,6 +321,7 @@ var __dpadBundleExports = (() => {
     onKeyUp(event) {
       switch (event.keyCode) {
         case 13:
+        case 32:
           event.preventDefault();
           if (this.currentlyFocusedItem) {
             this.currentlyFocusedItem.onItemClickStateChange(false);

--- a/examples/static-html/lib/dpad-controller.js
+++ b/examples/static-html/lib/dpad-controller.js
@@ -1,0 +1,332 @@
+var __dpadBundleExports = (() => {
+  var __defProp = Object.defineProperty;
+  var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+  var __getOwnPropNames = Object.getOwnPropertyNames;
+  var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __export = (target, all) => {
+    for (var name in all)
+      __defProp(target, name, { get: all[name], enumerable: true });
+  };
+  var __copyProps = (to, from, except, desc) => {
+    if (from && typeof from === "object" || typeof from === "function") {
+      for (let key of __getOwnPropNames(from))
+        if (!__hasOwnProp.call(to, key) && key !== except)
+          __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+    }
+    return to;
+  };
+  var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+  // src/lib/dpad-controller.ts
+  var dpad_controller_exports = {};
+  __export(dpad_controller_exports, {
+    DpadController: () => DpadController
+  });
+
+  // src/lib/_focusable-item.ts
+  var FocusableItem = class {
+    constructor(ele) {
+      this.focusState = false;
+      this.element = ele;
+      this.resetNeighbors();
+    }
+    getElement() {
+      return this.element;
+    }
+    focus() {
+      this.element.focus();
+    }
+    resetNeighbors() {
+      this.neighbors = {
+        top: null,
+        bottom: null,
+        left: null,
+        right: null
+      };
+    }
+    setTopFocusItemIndex(index) {
+      this.neighbors.top = index;
+    }
+    getTopFocusItemIndex() {
+      return this.neighbors.top;
+    }
+    setBottomFocusItemIndex(index) {
+      this.neighbors.bottom = index;
+    }
+    getBottomFocusItemIndex() {
+      return this.neighbors.bottom;
+    }
+    setLeftFocusItemIndex(index) {
+      this.neighbors.left = index;
+    }
+    getLeftFocusItemIndex() {
+      return this.neighbors.left;
+    }
+    setRightFocusItemIndex(index) {
+      this.neighbors.right = index;
+    }
+    getRightFocusItemIndex() {
+      return this.neighbors.right;
+    }
+    isFocusable() {
+      if (this.element.style.display === "none" || this.element.style.visibility === "hidden") {
+        return false;
+      }
+      let tabIndexAttr = this.element.getAttribute("tabindex");
+      if (!tabIndexAttr) {
+        return false;
+      }
+      try {
+        const tabIndex = parseInt(tabIndexAttr, 10);
+        return tabIndex > -1;
+      } catch (err) {
+      }
+      return false;
+    }
+    getMetrics() {
+      var clientRect = this.element.getBoundingClientRect();
+      return {
+        width: clientRect.width,
+        height: clientRect.height,
+        left: clientRect.left,
+        right: clientRect.left + clientRect.width,
+        top: clientRect.top,
+        bottom: clientRect.top + clientRect.height,
+        center: {
+          x: clientRect.left + clientRect.width / 2,
+          y: clientRect.top + clientRect.height / 2
+        }
+      };
+    }
+    onItemClickStateChange(isDown) {
+    }
+  };
+
+  // src/lib/_calc-distance.ts
+  function calcDistance(x, y) {
+    return Math.floor(Math.sqrt(x * x + y * y));
+  }
+
+  // src/lib/dpad-controller.ts
+  var FOCUSABLE_ITEM_SELECTOR = ".dpad-focusable";
+  var DpadController = class {
+    constructor() {
+      this.focusableItems = [];
+      this.currentlyFocusedItem = null;
+      this.enabled = false;
+      this.getRightDistance = function(fromMetrics, toMetrics) {
+        return this.horizontalDistance(fromMetrics, toMetrics, fromMetrics, toMetrics);
+      };
+      this.focusableItems = [];
+      this.onKeyDown = this.onKeyDown.bind(this);
+      this.onKeyUp = this.onKeyUp.bind(this);
+      this.enable();
+    }
+    disable() {
+      if (!this.enabled) {
+        return;
+      }
+      document.removeEventListener("keydown", this.onKeyDown);
+      document.removeEventListener("keyup", this.onKeyUp);
+      this.enabled = false;
+    }
+    enable() {
+      if (this.enabled) {
+        return;
+      }
+      document.addEventListener("keydown", this.onKeyDown);
+      document.addEventListener("keyup", this.onKeyUp);
+      this.enabled = true;
+    }
+    findFocusableItems() {
+      const focusableItems = document.querySelectorAll(FOCUSABLE_ITEM_SELECTOR);
+      for (const fi of focusableItems) {
+        this.addFocusableItem(new FocusableItem(fi));
+      }
+    }
+    addFocusableItem(i) {
+      this.focusableItems.push(i);
+    }
+    getFocusableItems() {
+      return this.focusableItems;
+    }
+    getFocusableItem(index) {
+      if (index >= this.focusableItems.length || index < 0) {
+        return null;
+      }
+      return this.focusableItems[index];
+    }
+    setCurrentFocusItem(i) {
+      const fi = this.getFocusableItem(i);
+      this.currentlyFocusedItem = fi;
+      if (!this.currentlyFocusedItem) {
+        return;
+      }
+      this.currentlyFocusedItem.focus();
+    }
+    update() {
+      this.focusableItems = [];
+      this.findFocusableItems();
+      const previouslyFocusedItem = this.currentlyFocusedItem;
+      this.currentlyFocusedItem = null;
+      for (const fi of this.focusableItems) {
+        if (!fi.isFocusable()) {
+          continue;
+        }
+        if (previouslyFocusedItem && fi.getElement() == previouslyFocusedItem.getElement()) {
+          this.currentlyFocusedItem = fi;
+        }
+        this.updateNeighbors(fi);
+      }
+    }
+    moveFocus(direction) {
+      if (!this.currentlyFocusedItem) {
+        if (this.focusableItems.length > 0) {
+          this.setCurrentFocusItem(0);
+        }
+        return;
+      }
+      var nextItemIndex = null;
+      if (direction.y === 0) {
+        if (direction.x > 0) {
+          nextItemIndex = this.currentlyFocusedItem.getRightFocusItemIndex();
+        } else {
+          nextItemIndex = this.currentlyFocusedItem.getLeftFocusItemIndex();
+        }
+      } else if (direction.x === 0) {
+        if (direction.y > 0) {
+          nextItemIndex = this.currentlyFocusedItem.getTopFocusItemIndex();
+        } else {
+          nextItemIndex = this.currentlyFocusedItem.getBottomFocusItemIndex();
+        }
+      }
+      if (nextItemIndex !== null) {
+        this.setCurrentFocusItem(nextItemIndex);
+      }
+    }
+    updateNeighbors(fi) {
+      const metrics = fi.getMetrics();
+      const itemCount = this.focusableItems.length;
+      let minTopElementDist;
+      let minBottomElementDist;
+      let minLeftElementDist;
+      let minRightElementDist;
+      for (var i = 0; i < itemCount; i++) {
+        var newItem = this.getFocusableItem(i);
+        if (!newItem.isFocusable() || newItem === fi) {
+          continue;
+        }
+        const newItemMetrics = newItem.getMetrics();
+        const distanceTop = this.getTopDistance(metrics, newItemMetrics);
+        const distanceBottom = this.getBottomDistance(metrics, newItemMetrics);
+        const distanceLeft = this.getLeftDistance(metrics, newItemMetrics);
+        const distanceRight = this.getRightDistance(metrics, newItemMetrics);
+        if (distanceTop !== null && (typeof minTopElementDist === "undefined" || minTopElementDist > distanceTop)) {
+          minTopElementDist = distanceTop;
+          fi.setTopFocusItemIndex(i);
+        }
+        if (distanceBottom !== null && (typeof minBottomElementDist === "undefined" || minBottomElementDist > distanceBottom)) {
+          minBottomElementDist = distanceBottom;
+          fi.setBottomFocusItemIndex(i);
+        }
+        if (distanceLeft !== null && (typeof minLeftElementDist === "undefined" || minLeftElementDist > distanceLeft)) {
+          minLeftElementDist = distanceLeft;
+          fi.setLeftFocusItemIndex(i);
+        }
+        if (distanceRight !== null && (typeof minRightElementDist === "undefined" || minRightElementDist > distanceRight)) {
+          minRightElementDist = distanceRight;
+          fi.setRightFocusItemIndex(i);
+        }
+      }
+    }
+    verticalDistance(fromMetrics, toMetrics, higher, lower) {
+      if (higher.bottom > lower.top) {
+        return null;
+      }
+      const left = Math.abs(fromMetrics.center.x - toMetrics.left);
+      const right = Math.abs(fromMetrics.center.x - toMetrics.right);
+      const x = Math.min(
+        Math.abs(fromMetrics.center.x - toMetrics.left),
+        Math.abs(fromMetrics.center.x - toMetrics.center.x),
+        Math.abs(fromMetrics.center.x - toMetrics.right)
+      );
+      const y = lower.center.y - higher.center.y;
+      const angleLeft = Math.atan(y / left) * (180 / Math.PI);
+      const angleRight = Math.atan(y / right) * (180 / Math.PI);
+      if (!(angleLeft >= 0 && angleRight <= 180)) {
+        return null;
+      }
+      return calcDistance(x, y);
+    }
+    getTopDistance(fromMetrics, toMetrics) {
+      return this.verticalDistance(fromMetrics, toMetrics, toMetrics, fromMetrics);
+    }
+    getBottomDistance(fromMetrics, toMetrics) {
+      return this.verticalDistance(fromMetrics, toMetrics, fromMetrics, toMetrics);
+    }
+    horizontalDistance(fromMetrics, toMetrics, lefter, righter) {
+      if (lefter.right > righter.left) {
+        return null;
+      }
+      const top = Math.abs(fromMetrics.center.y - toMetrics.top);
+      const bottom = Math.abs(fromMetrics.center.y - toMetrics.bottom);
+      const x = righter.center.x - lefter.center.x;
+      const y = Math.min(
+        Math.abs(fromMetrics.center.y - toMetrics.top),
+        Math.abs(fromMetrics.center.y - toMetrics.center.y),
+        Math.abs(fromMetrics.center.y - toMetrics.bottom)
+      );
+      var angleTop = Math.atan(x / top) * (180 / Math.PI);
+      var angleBottom = Math.atan(x / bottom) * (180 / Math.PI);
+      if (!(angleTop >= 0 && angleBottom <= 180)) {
+        return null;
+      }
+      return calcDistance(x, y);
+    }
+    getLeftDistance(fromMetrics, toMetrics) {
+      return this.horizontalDistance(fromMetrics, toMetrics, toMetrics, fromMetrics);
+    }
+    onKeyDown(event) {
+      switch (event.keyCode) {
+        case 9:
+          break;
+        case 37:
+          event.preventDefault();
+          this.moveFocus({ x: -1, y: 0 });
+          break;
+        case 38:
+          event.preventDefault();
+          this.moveFocus({ x: 0, y: 1 });
+          break;
+        case 39:
+          event.preventDefault();
+          this.moveFocus({ x: 1, y: 0 });
+          break;
+        case 40:
+          event.preventDefault();
+          this.moveFocus({ x: 0, y: -1 });
+          break;
+        case 13:
+        case 32:
+          event.preventDefault();
+          if (this.currentlyFocusedItem) {
+            this.currentlyFocusedItem.onItemClickStateChange(true);
+          }
+          break;
+      }
+    }
+    onKeyUp(event) {
+      switch (event.keyCode) {
+        case 13:
+          event.preventDefault();
+          if (this.currentlyFocusedItem) {
+            this.currentlyFocusedItem.onItemClickStateChange(false);
+          }
+          break;
+      }
+    }
+  };
+  return __toCommonJS(dpad_controller_exports);
+})();
+window.gauntface = window.gauntface || {};
+window.gauntface.dpad = Object.assign(window.gauntface.dpad || {}, __dpadBundleExports);

--- a/examples/static-html/lists.html
+++ b/examples/static-html/lists.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Cinematic Highlights — dpad-nav demo</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700;800&family=JetBrains+Mono:wght@500;700&display=swap" />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
+<link rel="stylesheet" href="css/theme.css" />
+<style>
+  .lists-shell {
+    display: flex;
+    gap: 56px;
+    align-items: flex-start;
+  }
+  .categories {
+    width: 260px;
+    flex: none;
+  }
+  .categories h4 {
+    font-family: 'JetBrains Mono', monospace;
+    letter-spacing: 0.15em;
+    font-size: 13px;
+    color: var(--on-surface-variant);
+    margin-bottom: 20px;
+  }
+  .categories .list-focus {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 16px 20px;
+    border-radius: 10px;
+    font-size: 16px;
+    background: transparent;
+    border: none;
+    color: var(--on-surface);
+    width: 100%;
+    text-align: left;
+    cursor: pointer;
+    font-family: inherit;
+  }
+  .content-col {
+    flex: 1;
+    min-width: 0;
+  }
+  .content-col h2 {
+    font-size: 32px;
+    margin: 0 0 8px;
+  }
+  .content-col > p {
+    color: var(--on-surface-variant);
+    margin: 0 0 32px;
+  }
+  .media-row {
+    display: flex;
+    gap: 24px;
+    border-radius: 14px;
+    border: 1px solid var(--outline-variant);
+    background: var(--surface-container);
+    padding: 20px;
+    margin-bottom: 20px;
+    align-items: center;
+  }
+  .media-row .thumb {
+    width: 220px;
+    height: 130px;
+    border-radius: 10px;
+    flex: none;
+  }
+  .media-row .body {
+    flex: 1;
+    min-width: 0;
+  }
+  .media-row .body h3 {
+    margin: 0 0 8px;
+    font-size: 24px;
+  }
+  .media-row .body p {
+    margin: 0 0 12px;
+    color: var(--on-surface-variant);
+    font-size: 15px;
+  }
+  .badge {
+    display: inline-block;
+    padding: 6px 16px;
+    border-radius: 999px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+    font-weight: 700;
+    float: right;
+  }
+  .meta {
+    display: flex;
+    gap: 20px;
+    color: var(--secondary);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 14px;
+  }
+  .axis-panel {
+    margin-top: 32px;
+    padding: 20px;
+    border-radius: 10px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 14px;
+  }
+  .axis-panel .row {
+    margin: 6px 0;
+    color: var(--on-surface-variant);
+  }
+  .axis-panel b {
+    color: var(--secondary);
+  }
+</style>
+</head>
+<body>
+<div class="app-shell">
+  <aside class="side-nav">
+    <div class="brand">
+      <span class="material-symbols-outlined icon">spatial_audio_off</span>
+      <span>Spatial Demo</span>
+    </div>
+    <nav>
+      <a class="nav-item" href="index.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
+        <span class="material-symbols-outlined icon">home</span><span>Home</span>
+      </a>
+      <a class="nav-item" href="grid.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
+        <span class="material-symbols-outlined icon">grid_view</span><span>Grid Demo</span>
+      </a>
+      <button class="dpad-focusable nav-item active" tabindex="1">
+        <span class="material-symbols-outlined icon">list</span><span>Lists</span>
+      </button>
+      <a class="nav-item" href="settings.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
+        <span class="material-symbols-outlined icon">settings</span><span>Settings</span>
+      </a>
+    </nav>
+    <div class="avatar"></div>
+  </aside>
+
+  <main class="main no-scrollbar">
+    <div class="lists-shell">
+      <div class="categories">
+        <h4>CATEGORIES</h4>
+        <button class="dpad-focusable list-focus" tabindex="10" data-node-id="cat-recommended" data-axis="vertical" data-dpad-initial-focus>
+          <span class="material-symbols-outlined">auto_awesome</span>Recommended
+        </button>
+        <button class="dpad-focusable list-focus" tabindex="11" data-node-id="cat-originals" data-axis="vertical">
+          <span class="material-symbols-outlined">movie</span>Cinema Originals
+        </button>
+        <button class="dpad-focusable list-focus" tabindex="12" data-node-id="cat-recent" data-axis="vertical">
+          <span class="material-symbols-outlined">history</span>Recently Viewed
+        </button>
+        <button class="dpad-focusable list-focus" tabindex="13" data-node-id="cat-favorites" data-axis="vertical">
+          <span class="material-symbols-outlined">favorite</span>My Favorites
+        </button>
+
+        <div class="axis-panel glass-panel">
+          <div class="row">FOCUS_NODE_ID: <b data-current-pos>cat-recommended</b></div>
+          <div class="row">AXIS_LOCK: <b id="axis-lock">VERTICAL</b></div>
+        </div>
+      </div>
+
+      <div class="content-col">
+        <h2>Cinematic Highlights</h2>
+        <p>Explore the latest high-fidelity spatial experiences curated for the 10-foot UI.</p>
+
+        <div class="dpad-focusable media-row" tabindex="20" data-node-id="row-neon-genesis" data-axis="horizontal">
+          <div class="thumb" style="background: linear-gradient(135deg, #1b2a4a, #0b1326);"></div>
+          <div class="body">
+            <span class="badge" style="background: var(--primary); color: var(--on-primary);">ULTRA HD</span>
+            <h3>Neon Genesis</h3>
+            <p>A deep dive into the architecture of the 24th century.</p>
+            <div class="meta"><span>★ 4.9</span><span>2h 15m</span></div>
+          </div>
+        </div>
+
+        <div class="dpad-focusable media-row" tabindex="21" data-node-id="row-ethereal-peaks" data-axis="horizontal">
+          <div class="thumb" style="background: linear-gradient(135deg, #3a1b4a, #0b1326);"></div>
+          <div class="body">
+            <span class="badge" style="background: var(--secondary); color: #2c0051;">HDR10+</span>
+            <h3>Ethereal Peaks</h3>
+            <p>Escape to the highest altitudes of the world.</p>
+            <div class="meta"><span>★ 4.8</span><span>1h 40m</span></div>
+          </div>
+        </div>
+
+        <div class="dpad-focusable media-row" tabindex="22" data-node-id="row-liquid-motion" data-axis="horizontal">
+          <div class="thumb" style="background: linear-gradient(135deg, #0f4a3a, #0b1326);"></div>
+          <div class="body">
+            <span class="badge" style="background: var(--tertiary); color: #00363e;">SPATIAL AUDIO</span>
+            <h3>Liquid Motion</h3>
+            <p>An abstract exploration of fluid dynamics.</p>
+            <div class="meta"><span>★ 5.0</span><span>45m</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+
+<div class="debug-hud glass-panel mono" id="debug-hud">
+  <div><span class="dot"></span><b>SPATIAL NODE ACTIVE</b></div>
+  <div class="row">ID: <b id="debug-hud-id">none</b></div>
+  <div class="row">TABINDEX: <b id="debug-hud-tabindex">0</b></div>
+  <div class="row">COORDS: <b id="debug-hud-coords">0, 0</b></div>
+</div>
+
+<script src="lib/dpad-controller.js"></script>
+<script src="lib/debug-controller.js"></script>
+<script src="lib/app.js"></script>
+<script>
+  document.querySelectorAll('.dpad-focusable[data-axis]').forEach((el) => {
+    el.addEventListener('focus', () => {
+      const lock = document.getElementById('axis-lock');
+      if (lock) lock.textContent = el.dataset.axis.toUpperCase();
+    });
+  });
+</script>
+</body>
+</html>

--- a/examples/static-html/lists.html
+++ b/examples/static-html/lists.html
@@ -120,16 +120,16 @@
       <span class="label">Spatial Demo</span>
     </div>
     <nav>
-      <a class="nav-item" href="index.html">
+      <a class="dpad-focusable nav-item" href="index.html" tabindex="0" data-node-id="nav-home">
         <span class="material-symbols-outlined icon">home</span><span class="label">Home</span>
       </a>
-      <a class="nav-item" href="grid.html">
+      <a class="dpad-focusable nav-item" href="grid.html" tabindex="0" data-node-id="nav-grid">
         <span class="material-symbols-outlined icon">grid_view</span><span class="label">Grid Demo</span>
       </a>
-      <button class="dpad-focusable nav-item active" tabindex="1">
+      <button class="dpad-focusable nav-item active" tabindex="0" data-node-id="nav-lists">
         <span class="material-symbols-outlined icon">list</span><span class="label">Lists</span>
       </button>
-      <a class="nav-item" href="settings.html">
+      <a class="dpad-focusable nav-item" href="settings.html" tabindex="0" data-node-id="nav-settings">
         <span class="material-symbols-outlined icon">settings</span><span class="label">Settings</span>
       </a>
     </nav>

--- a/examples/static-html/lists.html
+++ b/examples/static-html/lists.html
@@ -117,20 +117,20 @@
   <aside class="side-nav">
     <div class="brand">
       <span class="material-symbols-outlined icon">spatial_audio_off</span>
-      <span>Spatial Demo</span>
+      <span class="label">Spatial Demo</span>
     </div>
     <nav>
-      <a class="nav-item" href="index.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
-        <span class="material-symbols-outlined icon">home</span><span>Home</span>
+      <a class="nav-item" href="index.html">
+        <span class="material-symbols-outlined icon">home</span><span class="label">Home</span>
       </a>
-      <a class="nav-item" href="grid.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
-        <span class="material-symbols-outlined icon">grid_view</span><span>Grid Demo</span>
+      <a class="nav-item" href="grid.html">
+        <span class="material-symbols-outlined icon">grid_view</span><span class="label">Grid Demo</span>
       </a>
       <button class="dpad-focusable nav-item active" tabindex="1">
-        <span class="material-symbols-outlined icon">list</span><span>Lists</span>
+        <span class="material-symbols-outlined icon">list</span><span class="label">Lists</span>
       </button>
-      <a class="nav-item" href="settings.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
-        <span class="material-symbols-outlined icon">settings</span><span>Settings</span>
+      <a class="nav-item" href="settings.html">
+        <span class="material-symbols-outlined icon">settings</span><span class="label">Settings</span>
       </a>
     </nav>
     <div class="avatar"></div>

--- a/examples/static-html/settings.html
+++ b/examples/static-html/settings.html
@@ -120,11 +120,37 @@
     align-items: center;
     gap: 12px;
     padding: 12px 0;
+    background: none;
+    border: none;
+    color: inherit;
+    font: inherit;
+    font-size: 15px;
+    width: 100%;
+    text-align: left;
+    cursor: pointer;
   }
-  .checkbox-row input {
+  .checkbox-box {
     width: 20px;
     height: 20px;
-    accent-color: var(--primary);
+    flex: none;
+    border-radius: 4px;
+    border: 2px solid var(--outline);
+    position: relative;
+  }
+  .checkbox-box.checked {
+    background: var(--primary);
+    border-color: var(--primary);
+  }
+  .checkbox-box.checked::after {
+    content: '';
+    position: absolute;
+    left: 6px;
+    top: 2px;
+    width: 5px;
+    height: 10px;
+    border: solid var(--on-primary);
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
   }
   .reset-btn {
     align-self: center;
@@ -205,12 +231,12 @@
           </div>
           <div class="panel">
             <h5>Telemetry Nodes</h5>
-            <label class="checkbox-row dpad-focusable" tabindex="22" data-node-id="show-focus-vectors" data-dpad-debug-toggle="checkbox">
-              <input type="checkbox" tabindex="-1" />Show Focus Vectors
-            </label>
-            <label class="checkbox-row dpad-focusable" tabindex="23" data-node-id="z-space-debugging">
-              <input type="checkbox" tabindex="-1" />Z-Space Debugging
-            </label>
+            <button type="button" class="checkbox-row dpad-focusable" tabindex="22" data-node-id="show-focus-vectors" data-dpad-debug-toggle="checkbox">
+              <span class="checkbox-box" aria-hidden="true"></span>Show Focus Vectors
+            </button>
+            <button type="button" class="checkbox-row dpad-focusable" tabindex="23" data-node-id="z-space-debugging">
+              <span class="checkbox-box" aria-hidden="true"></span>Z-Space Debugging
+            </button>
           </div>
         </div>
 
@@ -234,28 +260,21 @@
 <script src="lib/debug-controller.js"></script>
 <script src="lib/app.js"></script>
 <script>
-  // Cosmetic switch/checkbox toggling (not part of the library) — OK/Enter
-  // on a focused switch flips it, matching the "Press OK to toggle" pattern
-  // a real TV remote would use.
+  // Cosmetic switch/checkbox toggling (not part of the library). Both are
+  // real <button> elements, so app.js's global Enter/Space-clicks-the-
+  // focused-element bridge (see lib/app.js) already covers keyboard
+  // activation here -- this just handles the click itself.
   document.querySelectorAll('.switch').forEach((el) => {
     el.addEventListener('click', () => {
       const on = el.classList.toggle('on');
       el.setAttribute('aria-checked', String(on));
     });
-    el.addEventListener('keyup', (e) => {
-      if (e.key === 'Enter' || e.key === ' ') el.click();
-    });
   });
   document.querySelectorAll('.checkbox-row').forEach((row) => {
-    const box = row.querySelector('input');
-    row.addEventListener('click', (e) => {
-      if (row.dataset.dpadDebugToggle) return; // handled by app.js
-      box.checked = !box.checked;
-    });
-    row.addEventListener('keyup', (e) => {
-      if ((e.key === 'Enter' || e.key === ' ') && !row.dataset.dpadDebugToggle) {
-        box.checked = !box.checked;
-      }
+    if (row.dataset.dpadDebugToggle) return; // handled by app.js
+    const box = row.querySelector('.checkbox-box');
+    row.addEventListener('click', () => {
+      box.classList.toggle('checked');
     });
   });
 </script>

--- a/examples/static-html/settings.html
+++ b/examples/static-html/settings.html
@@ -176,16 +176,16 @@
       <span class="label">Spatial Demo</span>
     </div>
     <nav>
-      <a class="nav-item" href="index.html">
+      <a class="dpad-focusable nav-item" href="index.html" tabindex="0" data-node-id="nav-home">
         <span class="material-symbols-outlined icon">home</span><span class="label">Home</span>
       </a>
-      <a class="nav-item" href="grid.html">
+      <a class="dpad-focusable nav-item" href="grid.html" tabindex="0" data-node-id="nav-grid">
         <span class="material-symbols-outlined icon">grid_view</span><span class="label">Grid Demo</span>
       </a>
-      <a class="nav-item" href="lists.html">
+      <a class="dpad-focusable nav-item" href="lists.html" tabindex="0" data-node-id="nav-lists">
         <span class="material-symbols-outlined icon">list</span><span class="label">Lists</span>
       </a>
-      <button class="dpad-focusable nav-item active" tabindex="1">
+      <button class="dpad-focusable nav-item active" tabindex="0" data-node-id="nav-settings">
         <span class="material-symbols-outlined icon">settings</span><span class="label">Settings</span>
       </button>
     </nav>

--- a/examples/static-html/settings.html
+++ b/examples/static-html/settings.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Settings — dpad-nav demo</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700;800&family=JetBrains+Mono:wght@500;700&display=swap" />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
+<link rel="stylesheet" href="css/theme.css" />
+<style>
+  .settings-shell {
+    display: flex;
+    gap: 56px;
+    align-items: flex-start;
+  }
+  .settings-nav {
+    width: 240px;
+    flex: none;
+  }
+  .settings-nav h4 {
+    font-size: 18px;
+    color: var(--on-surface-variant);
+    margin: 0 0 20px;
+  }
+  .settings-nav .list-focus {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 16px 20px;
+    border-radius: 10px;
+    background: transparent;
+    border: none;
+    color: var(--on-surface);
+    width: 100%;
+    text-align: left;
+    cursor: pointer;
+    font: inherit;
+    font-size: 16px;
+    margin-bottom: 8px;
+  }
+  .settings-nav .list-focus.active {
+    background: var(--surface-container-high);
+    border-left: 4px solid var(--primary);
+  }
+  .panels {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    max-width: 760px;
+  }
+  .panel {
+    background: var(--surface-container);
+    border: 1px solid var(--outline-variant);
+    border-radius: 14px;
+    padding: 28px;
+  }
+  .panel h5 {
+    margin: 0 0 16px;
+    font-size: 16px;
+    font-weight: 600;
+  }
+  .panel p {
+    color: var(--on-surface-variant);
+    font-size: 15px;
+    line-height: 1.5;
+    margin: 0 0 16px;
+  }
+  .panel-cols {
+    display: flex;
+    gap: 24px;
+  }
+  .panel-cols .panel {
+    flex: 1;
+  }
+  .field {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: var(--surface-container-high);
+    border-radius: 10px;
+    padding: 16px 20px;
+  }
+  .field .hint {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--on-surface-variant);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 13px;
+  }
+  .switch {
+    width: 46px;
+    height: 26px;
+    border-radius: 999px;
+    background: var(--surface-bright);
+    border: none;
+    position: relative;
+    cursor: pointer;
+  }
+  .switch::after {
+    content: '';
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    border-radius: 999px;
+    background: white;
+    top: 3px;
+    left: 3px;
+    transition: left 0.2s ease;
+  }
+  .switch.on {
+    background: var(--primary);
+  }
+  .switch.on::after {
+    left: 23px;
+  }
+  .checkbox-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 0;
+  }
+  .checkbox-row input {
+    width: 20px;
+    height: 20px;
+    accent-color: var(--primary);
+  }
+  .reset-btn {
+    align-self: center;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 18px 40px;
+    border-radius: 999px;
+    border: none;
+    background: var(--secondary);
+    color: #2c0051;
+    font-weight: 700;
+    font-size: 16px;
+    cursor: pointer;
+  }
+</style>
+</head>
+<body>
+<div class="app-shell">
+  <aside class="side-nav">
+    <div class="brand">
+      <span class="material-symbols-outlined icon">spatial_audio_off</span>
+      <span>Spatial Demo</span>
+    </div>
+    <nav>
+      <a class="nav-item" href="index.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
+        <span class="material-symbols-outlined icon">home</span><span>Home</span>
+      </a>
+      <a class="nav-item" href="grid.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
+        <span class="material-symbols-outlined icon">grid_view</span><span>Grid Demo</span>
+      </a>
+      <a class="nav-item" href="lists.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
+        <span class="material-symbols-outlined icon">list</span><span>Lists</span>
+      </a>
+      <button class="dpad-focusable nav-item active" tabindex="1">
+        <span class="material-symbols-outlined icon">settings</span><span>Settings</span>
+      </button>
+    </nav>
+    <div class="avatar"></div>
+  </aside>
+
+  <main class="main no-scrollbar">
+    <div class="settings-shell">
+      <div class="settings-nav">
+        <h4>Settings</h4>
+        <button class="dpad-focusable list-focus active" tabindex="10" data-node-id="settings-display" data-dpad-initial-focus>
+          <span class="material-symbols-outlined">desktop_windows</span>Display
+        </button>
+        <button class="dpad-focusable list-focus" tabindex="11" data-node-id="settings-audio">
+          <span class="material-symbols-outlined">volume_up</span>Audio &amp; Voice
+        </button>
+        <button class="dpad-focusable list-focus" tabindex="12" data-node-id="settings-network">
+          <span class="material-symbols-outlined">wifi</span>Network
+        </button>
+        <button class="dpad-focusable list-focus" tabindex="13" data-node-id="settings-privacy">
+          <span class="material-symbols-outlined">shield</span>Privacy
+        </button>
+      </div>
+
+      <div class="panels">
+        <div class="panel">
+          <h5>Device Identity</h5>
+          <div class="field dpad-focusable" tabindex="20" data-node-id="device-name" style="border: 2px solid transparent;">
+            <span>Spatial-Node-01</span>
+            <span class="hint"><span class="material-symbols-outlined" style="font-size: 16px;">edit</span>Press OK to Edit</span>
+          </div>
+          <p style="margin-top: 16px; margin-bottom: 0;">The name displayed when broadcasting to other spatial nodes on your network.</p>
+        </div>
+
+        <div class="panel-cols">
+          <div class="panel">
+            <h5>Atmospheric Depth</h5>
+            <p>Enable background shaders and glassmorphism effects for a more immersive experience.</p>
+            <div class="field">
+              <span>Enable Shader Layer</span>
+              <button class="dpad-focusable switch on" tabindex="21" data-node-id="shader-layer" role="switch" aria-checked="true"></button>
+            </div>
+          </div>
+          <div class="panel">
+            <h5>Telemetry Nodes</h5>
+            <label class="checkbox-row dpad-focusable" tabindex="22" data-node-id="show-focus-vectors" data-dpad-debug-toggle="checkbox">
+              <input type="checkbox" tabindex="-1" />Show Focus Vectors
+            </label>
+            <label class="checkbox-row dpad-focusable" tabindex="23" data-node-id="z-space-debugging">
+              <input type="checkbox" tabindex="-1" />Z-Space Debugging
+            </label>
+          </div>
+        </div>
+
+        <button class="dpad-focusable reset-btn" tabindex="24" data-node-id="reset-focus-state" data-dpad-reset>
+          <span class="material-symbols-outlined">restart_alt</span>Reset Focus State
+        </button>
+      </div>
+    </div>
+  </main>
+</div>
+
+<div class="debug-hud glass-panel mono visible" id="debug-hud" style="bottom: 32px; right: 32px;">
+  <div><span class="dot"></span><b>SPATIAL DEBUGGER ACTIVE</b></div>
+  <div class="row">Focus ID: <b id="debug-hud-id">NONE</b></div>
+  <div class="row">Traversal: <b>D-PAD_LIBRARY</b></div>
+  <div class="row" style="display:none;">TABINDEX: <b id="debug-hud-tabindex">0</b></div>
+  <div class="row" style="display:none;">COORDS: <b id="debug-hud-coords">0, 0</b></div>
+</div>
+
+<script src="lib/dpad-controller.js"></script>
+<script src="lib/debug-controller.js"></script>
+<script src="lib/app.js"></script>
+<script>
+  // Cosmetic switch/checkbox toggling (not part of the library) — OK/Enter
+  // on a focused switch flips it, matching the "Press OK to toggle" pattern
+  // a real TV remote would use.
+  document.querySelectorAll('.switch').forEach((el) => {
+    el.addEventListener('click', () => {
+      const on = el.classList.toggle('on');
+      el.setAttribute('aria-checked', String(on));
+    });
+    el.addEventListener('keyup', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') el.click();
+    });
+  });
+  document.querySelectorAll('.checkbox-row').forEach((row) => {
+    const box = row.querySelector('input');
+    row.addEventListener('click', (e) => {
+      if (row.dataset.dpadDebugToggle) return; // handled by app.js
+      box.checked = !box.checked;
+    });
+    row.addEventListener('keyup', (e) => {
+      if ((e.key === 'Enter' || e.key === ' ') && !row.dataset.dpadDebugToggle) {
+        box.checked = !box.checked;
+      }
+    });
+  });
+</script>
+</body>
+</html>

--- a/examples/static-html/settings.html
+++ b/examples/static-html/settings.html
@@ -173,20 +173,20 @@
   <aside class="side-nav">
     <div class="brand">
       <span class="material-symbols-outlined icon">spatial_audio_off</span>
-      <span>Spatial Demo</span>
+      <span class="label">Spatial Demo</span>
     </div>
     <nav>
-      <a class="nav-item" href="index.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
-        <span class="material-symbols-outlined icon">home</span><span>Home</span>
+      <a class="nav-item" href="index.html">
+        <span class="material-symbols-outlined icon">home</span><span class="label">Home</span>
       </a>
-      <a class="nav-item" href="grid.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
-        <span class="material-symbols-outlined icon">grid_view</span><span>Grid Demo</span>
+      <a class="nav-item" href="grid.html">
+        <span class="material-symbols-outlined icon">grid_view</span><span class="label">Grid Demo</span>
       </a>
-      <a class="nav-item" href="lists.html" style="text-decoration:none; display:flex; align-items:center; gap:16px; padding:14px 24px;">
-        <span class="material-symbols-outlined icon">list</span><span>Lists</span>
+      <a class="nav-item" href="lists.html">
+        <span class="material-symbols-outlined icon">list</span><span class="label">Lists</span>
       </a>
       <button class="dpad-focusable nav-item active" tabindex="1">
-        <span class="material-symbols-outlined icon">settings</span><span>Settings</span>
+        <span class="material-symbols-outlined icon">settings</span><span class="label">Settings</span>
       </button>
     </nav>
     <div class="avatar"></div>


### PR DESCRIPTION
## Summary
- Adds `examples/static-html/`, a four-screen "10-foot UI" demo (`SpatialExplorer`) built from a set of Stitch mocks designed to stress-test spatial navigation, wired to the real `DpadController`/`DebugController` from this library — no framework, no build step.
- Screens: home (hero + shelves), "Navigation Lab" (irregular 5-column grid with wide/spanning nodes), vertical lists (categories + content), settings (buttons/switch/checkboxes, with a "Show Focus Vectors" checkbox wired to the library's own debug overlay).
- Vendors `build/browser/{dpad-controller,debug-controller}.js` from this repo's own build (post #25 fix) rather than the currently-published npm package, since the published package still has a namespace-clobbering bug where loading `debug-controller.js` after `dpad-controller.js` wipes out `window.gauntface.dpad.DpadController` — this rebuild's footer-merge fix resolves that.

## Test plan
- [x] Served locally (`python3 -m http.server`) and drove all four pages end-to-end with a real headless Chrome + keyboard events (not just visually) — verified initial focus, arrow-key traversal including the irregular grid spans, rail auto-scroll, debug HUD updates, and the debug-vector overlay toggle (confirmed 48 debug lines rendered on the grid page).
- [x] Confirmed the grid page's "skip the wide node" navigation quirk is genuine library distance-scoring behavior, not a demo bug (verified via bounding-box math).
- [x] No console/page errors other than the browser's own default favicon.ico request.