### PR TITLE
Add React demo — SpatialExplorer

### DIFF
--- a/examples/react/.gitignore
+++ b/examples/react/.gitignore
@@ -1,0 +1,2 @@
+dist/
+*.tsbuildinfo

--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -1,0 +1,40 @@
+# React demo
+
+The same four-screen `SpatialExplorer` demo as `examples/static-html` and
+`examples/svelte`, this time as a React 19 + Vite + TypeScript SPA
+(hash-routed, no router dependency, CSS Modules for per-page styles),
+consuming `@gauntface/dpad-nav` as a real npm dependency (`file:../..`).
+
+## Running it
+
+```sh
+npm install
+npm run dev      # dev server
+npm run build    # tsc -b && vite build, output to dist/
+```
+
+## How it's wired
+
+`src/lib/dpad.ts` creates a single `DpadController`/`DebugController` pair
+for the app's lifetime and exposes:
+
+- `refreshDpad()` / `focusInitial()` — called from `useDpadLifecycle(route)`
+  in a `useLayoutEffect` after every route change, once React has committed
+  the new page's DOM
+- `useDebugOn()` / `useFocusedNode()` — tiny external stores (subscribed via
+  `useSyncExternalStore`) that `TopBar`, `Grid`, `Settings` and `DebugHud`
+  read from; `toggleDebug()` is the one place that should ever flip debug
+  mode, so every consumer (the top bar's bug icon *and* the settings page's
+  "Show Focus Vectors" button) stays in sync
+
+### A note on keyboard activation
+
+`DpadController`'s Enter/Space handling calls `preventDefault()` and routes
+to `FocusableItem#onItemClickStateChange`, which is a no-op unless you
+supply a custom `FocusableItem`. That means a focused `<button>` does *not*
+activate on Enter the way native browser focus normally would — the library
+only manages *movement*, not *activation*. `useDpadLifecycle` restores the
+expected behavior generically: on Enter/Space keyup, if
+`document.activeElement` is `.dpad-focusable`, it gets `.click()`'d. Real
+apps using this library will want the same bridge (or a `FocusableItem`
+subclass wired to their own activation semantics).

--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -29,12 +29,10 @@ for the app's lifetime and exposes:
 
 ### A note on keyboard activation
 
-`DpadController`'s Enter/Space handling calls `preventDefault()` and routes
-to `FocusableItem#onItemClickStateChange`, which is a no-op unless you
-supply a custom `FocusableItem`. That means a focused `<button>` does *not*
-activate on Enter the way native browser focus normally would — the library
-only manages *movement*, not *activation*. `useDpadLifecycle` restores the
-expected behavior generically: on Enter/Space keyup, if
-`document.activeElement` is `.dpad-focusable`, it gets `.click()`'d. Real
-apps using this library will want the same bridge (or a `FocusableItem`
-subclass wired to their own activation semantics).
+Enter/Space activating whatever's focused is handled by the library itself
+([#67](https://github.com/gauntface/dpad-navigation/pull/67)) — this demo
+used to bridge it manually in `useDpadLifecycle` because that behavior had
+regressed during the library's TypeScript rewrite, but that workaround is
+no longer needed (and would double-fire clicks if kept alongside the
+library's own fix). If you need different press/release semantics, subclass
+`FocusableItem` and override `onItemClickStateChange`.

--- a/examples/react/index.html
+++ b/examples/react/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>SpatialExplorer — dpad-nav React demo</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700;800&family=JetBrains+Mono:wght@500;700&display=swap" />
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
+</head>
+<body>
+<div id="root"></div>
+<script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/examples/react/package-lock.json
+++ b/examples/react/package-lock.json
@@ -1,0 +1,1018 @@
+{
+  "name": "dpad-nav-demo-react",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dpad-nav-demo-react",
+      "version": "0.0.0",
+      "dependencies": {
+        "@gauntface/dpad-nav": "file:../..",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.4",
+        "@vitejs/plugin-react": "^6.0.5",
+        "typescript": "^6.0.3",
+        "vite": "^8.2.0"
+      }
+    },
+    "../..": {
+      "name": "@gauntface/dpad-nav",
+      "version": "3.0.1",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "esbuild": "^0.28.1",
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "2.0.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@gauntface/dpad-nav": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.1.tgz",
+      "integrity": "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.1.tgz",
+      "integrity": "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.1.tgz",
+      "integrity": "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.1.tgz",
+      "integrity": "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.1.tgz",
+      "integrity": "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.1.tgz",
+      "integrity": "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.1.tgz",
+      "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.1.tgz",
+      "integrity": "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.1.tgz",
+      "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.1.tgz",
+      "integrity": "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.1.tgz",
+      "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.1.tgz",
+      "integrity": "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.1.tgz",
+      "integrity": "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "2.0.0-alpha.3",
+        "@emnapi/runtime": "2.0.0-alpha.3",
+        "@napi-rs/wasm-runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.1.tgz",
+      "integrity": "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.1.tgz",
+      "integrity": "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.5.tgz",
+      "integrity": "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.1.tgz",
+      "integrity": "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.142.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.1",
+        "@rolldown/binding-darwin-arm64": "1.2.1",
+        "@rolldown/binding-darwin-x64": "1.2.1",
+        "@rolldown/binding-freebsd-x64": "1.2.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.1",
+        "@rolldown/binding-linux-arm64-musl": "1.2.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-musl": "1.2.1",
+        "@rolldown/binding-openharmony-arm64": "1.2.1",
+        "@rolldown/binding-wasm32-wasi": "1.2.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.1",
+        "@rolldown/binding-win32-x64-msvc": "1.2.1"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
+      "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.23",
+        "rolldown": "~1.2.0",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "dpad-nav-demo-react",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@gauntface/dpad-nav": "file:../..",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
+    "@vitejs/plugin-react": "^6.0.5",
+    "typescript": "^6.0.3",
+    "vite": "^8.2.0"
+  }
+}

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -1,0 +1,42 @@
+import {useEffect, useState} from 'react';
+import SideNav from './lib/SideNav';
+import TopBar from './lib/TopBar';
+import DebugHud from './lib/DebugHud';
+import Home from './pages/Home';
+import Grid from './pages/Grid';
+import Lists from './pages/Lists';
+import Settings from './pages/Settings';
+import {useDpadLifecycle} from './lib/dpad';
+
+function routeFromHash(): string {
+  return window.location.hash.replace(/^#\/?/, '') || 'home';
+}
+
+export default function App() {
+  const [route, setRoute] = useState(routeFromHash());
+
+  useEffect(() => {
+    const onHashChange = () => setRoute(routeFromHash());
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, []);
+
+  useDpadLifecycle(route);
+
+  return (
+    <>
+      <div className="app-shell">
+        <SideNav route={route} />
+        <main className="main no-scrollbar">
+          <TopBar />
+          {route === 'grid' && <Grid />}
+          {route === 'lists' && <Lists />}
+          {route === 'settings' && <Settings />}
+          {route !== 'grid' && route !== 'lists' && route !== 'settings' && <Home />}
+        </main>
+      </div>
+      {/* Settings renders its own "SPATIAL DEBUGGER ACTIVE" HUD variant, so skip the generic one to avoid stacking two panels in the same corner. */}
+      {route !== 'settings' && <DebugHud />}
+    </>
+  );
+}

--- a/examples/react/src/app.css
+++ b/examples/react/src/app.css
@@ -1,0 +1,277 @@
+:root {
+  --surface: #0b1326;
+  --surface-container-lowest: #060e20;
+  --surface-container-low: #131b2e;
+  --surface-container: #171f33;
+  --surface-container-high: #222a3d;
+  --surface-container-highest: #2d3449;
+  --surface-bright: #31394d;
+  --on-surface: #dae2fd;
+  --on-surface-variant: #c7c4d7;
+  --outline: #908fa0;
+  --outline-variant: #464554;
+  --primary: #c0c1ff;
+  --on-primary: #1000a9;
+  --secondary: #ddb7ff;
+  --tertiary: #2fd9f4;
+  --debug-vector: #10b981;
+  --focus-glow: rgba(99, 102, 241, 0.5);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--surface);
+  color: var(--on-surface);
+  font-family: 'Hanken Grotesk', system-ui, sans-serif;
+  overflow: hidden;
+}
+
+.mono {
+  font-family: 'JetBrains Mono', monospace;
+}
+
+/* Layout shell shared by every page */
+.app-shell {
+  display: flex;
+  height: 100vh;
+  width: 100vw;
+}
+
+.side-nav {
+  width: 88px;
+  flex: none;
+  background: rgba(23, 31, 51, 0.85);
+  backdrop-filter: blur(20px);
+  border-right: 1px solid var(--outline-variant);
+  display: flex;
+  flex-direction: column;
+  padding: 32px 0;
+  z-index: 50;
+  transition: width 0.25s ease;
+}
+
+.side-nav:hover {
+  width: 240px;
+}
+
+.side-nav .brand {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 0 24px;
+  margin-bottom: 48px;
+  color: var(--primary);
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.side-nav .brand .icon {
+  font-size: 28px;
+  flex: none;
+}
+
+.side-nav nav {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+}
+
+.side-nav .nav-item {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 24px;
+  border: none;
+  border-left: 4px solid transparent;
+  background: transparent;
+  color: var(--on-surface-variant);
+  font: inherit;
+  font-size: 16px;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-align: left;
+  text-decoration: none;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.side-nav .nav-item .icon {
+  flex: none;
+  font-size: 22px;
+}
+
+.side-nav .nav-item.active {
+  color: var(--primary);
+  border-left-color: var(--primary);
+  background: rgba(192, 193, 255, 0.08);
+}
+
+.side-nav .nav-item:hover {
+  color: var(--on-surface);
+  background: var(--surface-bright);
+}
+
+.side-nav .avatar {
+  margin: 0 24px;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--primary), var(--secondary));
+  flex: none;
+}
+
+.main {
+  flex: 1;
+  overflow-y: auto;
+  padding: 32px 64px 96px;
+  scroll-behavior: smooth;
+}
+
+.top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 0 40px;
+  position: sticky;
+  top: 0;
+  background: linear-gradient(to bottom, var(--surface) 60%, transparent);
+  z-index: 40;
+}
+
+.top-bar h1 {
+  font-size: 24px;
+  color: var(--primary);
+  margin: 0;
+}
+
+.top-bar-actions {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+
+.search-box {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--surface-container-high);
+  border: 1px solid var(--outline-variant);
+  border-radius: 999px;
+  padding: 10px 24px;
+  color: var(--on-surface-variant);
+}
+
+.icon-btn {
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  background: var(--surface-container);
+  border: 2px solid transparent;
+  color: var(--primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 20px;
+}
+
+.icon-btn.active {
+  border-color: var(--primary);
+  background: rgba(192, 193, 255, 0.15);
+}
+
+/* Focus behavior driven by the real dpad-nav library */
+.dpad-focusable {
+  outline: none !important;
+  transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.dpad-focusable:focus {
+  transform: scale(1.05);
+  z-index: 5;
+  position: relative;
+  border-color: var(--primary) !important;
+  box-shadow: 0 0 25px var(--focus-glow);
+}
+
+.list-focus:focus {
+  background: rgba(45, 52, 73, 0.6);
+}
+
+.list-focus {
+  position: relative;
+  border-left: 4px solid transparent;
+}
+
+.list-focus:focus {
+  border-left-color: var(--primary);
+}
+
+.glass-panel {
+  background: rgba(23, 31, 51, 0.75);
+  backdrop-filter: blur(20px);
+  border: 1px solid var(--outline-variant);
+}
+
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+.no-scrollbar {
+  scrollbar-width: none;
+}
+
+/* Debug HUD shown by the demo apps (not part of the library) */
+.debug-hud {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  z-index: 60;
+  padding: 20px 24px;
+  border-radius: 12px;
+  min-width: 260px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.debug-hud.visible {
+  opacity: 1;
+}
+
+.debug-hud .dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--debug-vector);
+  display: inline-block;
+  margin-right: 10px;
+  animation: pulse 1.6s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.debug-hud .row {
+  margin: 4px 0;
+  font-size: 14px;
+  color: var(--on-surface-variant);
+}
+
+.debug-hud .row b {
+  color: var(--primary);
+}
+
+/* d-pad debugger draws its own absolutely-positioned lines on <body>;
+   this just keeps them above everything else. */
+.dpad-debugger-line {
+  z-index: 999 !important;
+}

--- a/examples/react/src/lib/DebugHud.tsx
+++ b/examples/react/src/lib/DebugHud.tsx
@@ -1,0 +1,23 @@
+import {useFocusedNode} from './dpad';
+
+export default function DebugHud() {
+  const node = useFocusedNode();
+
+  return (
+    <div className={`debug-hud glass-panel mono${node ? ' visible' : ''}`}>
+      <div>
+        <span className="dot" />
+        <b>SPATIAL NODE ACTIVE</b>
+      </div>
+      <div className="row">
+        ID: <b>{node?.id ?? 'none'}</b>
+      </div>
+      <div className="row">
+        TABINDEX: <b>{node?.tabindex ?? 0}</b>
+      </div>
+      <div className="row">
+        COORDS: <b>{node ? `${node.x}, ${node.y}` : '0, 0'}</b>
+      </div>
+    </div>
+  );
+}

--- a/examples/react/src/lib/SideNav.tsx
+++ b/examples/react/src/lib/SideNav.tsx
@@ -1,0 +1,32 @@
+const items = [
+  {id: 'home', href: '#/', icon: 'home', label: 'Home'},
+  {id: 'grid', href: '#/grid', icon: 'grid_view', label: 'Grid Demo'},
+  {id: 'lists', href: '#/lists', icon: 'list', label: 'Lists'},
+  {id: 'settings', href: '#/settings', icon: 'settings', label: 'Settings'},
+];
+
+export default function SideNav({route}: {route: string}) {
+  return (
+    <aside className="side-nav">
+      <div className="brand">
+        <span className="material-symbols-outlined icon">spatial_audio_off</span>
+        <span>Spatial Demo</span>
+      </div>
+      <nav>
+        {items.map((item) => (
+          <a
+            key={item.id}
+            className={`dpad-focusable nav-item${route === item.id ? ' active' : ''}`}
+            href={item.href}
+            tabIndex={0}
+            data-node-id={`nav-${item.id}`}
+          >
+            <span className="material-symbols-outlined icon">{item.icon}</span>
+            <span>{item.label}</span>
+          </a>
+        ))}
+      </nav>
+      <div className="avatar" />
+    </aside>
+  );
+}

--- a/examples/react/src/lib/TopBar.tsx
+++ b/examples/react/src/lib/TopBar.tsx
@@ -1,0 +1,29 @@
+import {toggleDebug, useDebugOn} from './dpad';
+
+export default function TopBar() {
+  const debugOn = useDebugOn();
+
+  return (
+    <header className="top-bar">
+      <h1>SpatialExplorer</h1>
+      <div className="top-bar-actions">
+        <div className="search-box">
+          <span className="material-symbols-outlined">search</span>
+          <span>Search...</span>
+        </div>
+        <button
+          className={`dpad-focusable icon-btn${debugOn ? ' active' : ''}`}
+          tabIndex={0}
+          data-node-id="debug-toggle"
+          onClick={toggleDebug}
+          title="Toggle debug vectors"
+        >
+          <span className="material-symbols-outlined">bug_report</span>
+        </button>
+        <button className="dpad-focusable icon-btn" tabIndex={0} data-node-id="account" aria-label="Account">
+          <span className="material-symbols-outlined">account_circle</span>
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/examples/react/src/lib/dpad.ts
+++ b/examples/react/src/lib/dpad.ts
@@ -65,20 +65,6 @@ export function useDpadLifecycle(route: string) {
   }, [route]);
 
   useEffect(() => {
-    // DpadController.onKeyDown preventDefaults Enter/Space and routes to
-    // FocusableItem#onItemClickStateChange, which is a no-op unless you
-    // supply your own FocusableItem subclass -- so out of the box, a
-    // focused .dpad-focusable element does NOT activate on Enter the way
-    // native browser focus normally would. Restore that expectation
-    // generically: whatever's focused, click it.
-    const onKeyUp = (event: KeyboardEvent) => {
-      if (event.key !== 'Enter' && event.key !== ' ') return;
-      const el = document.activeElement;
-      if (el instanceof HTMLElement && el.classList.contains('dpad-focusable')) {
-        el.click();
-      }
-    };
-
     const onFocus = (event: FocusEvent) => {
       const el = event.target as HTMLElement;
       if (!el.classList?.contains('dpad-focusable')) return;
@@ -102,10 +88,8 @@ export function useDpadLifecycle(route: string) {
       }
     };
 
-    document.addEventListener('keyup', onKeyUp);
     document.addEventListener('focus', onFocus, true);
     return () => {
-      document.removeEventListener('keyup', onKeyUp);
       document.removeEventListener('focus', onFocus, true);
     };
   }, []);

--- a/examples/react/src/lib/dpad.ts
+++ b/examples/react/src/lib/dpad.ts
@@ -1,0 +1,112 @@
+import {DebugController, DpadController} from '@gauntface/dpad-nav';
+import {useEffect, useLayoutEffect, useSyncExternalStore} from 'react';
+
+// One controller pair for the whole app lifetime -- components just need
+// to call refreshDpad() (via useDpadRefresh below) after their focusable
+// elements render.
+export const dpad = new DpadController();
+export const debugController = new DebugController(dpad);
+
+export function refreshDpad() {
+  dpad.update();
+}
+
+export function focusInitial() {
+  const el = document.querySelector<HTMLElement>('[data-dpad-initial-focus]');
+  if (!el) return;
+  const items = dpad.getFocusableItems();
+  const index = items.findIndex((item) => item.getElement() === el);
+  if (index > -1) {
+    dpad.setCurrentFocusItem(index);
+  }
+}
+
+export function toggleDebug() {
+  debugController.toggleDebugMode();
+  debugOnStore.set(!debugOnStore.get());
+}
+
+// --- Minimal external stores, subscribed to via useSyncExternalStore -----
+
+function createStore<T>(initial: T) {
+  let value = initial;
+  const listeners = new Set<() => void>();
+  return {
+    get: () => value,
+    set(next: T) {
+      value = next;
+      listeners.forEach((l) => l());
+    },
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+}
+
+export type FocusedNode = {id: string; tabindex: number; x: number; y: number} | null;
+
+const debugOnStore = createStore(false);
+const focusedNodeStore = createStore<FocusedNode>(null);
+
+export function useDebugOn() {
+  return useSyncExternalStore(debugOnStore.subscribe, debugOnStore.get);
+}
+
+export function useFocusedNode() {
+  return useSyncExternalStore(focusedNodeStore.subscribe, focusedNodeStore.get);
+}
+
+/** Call once, at the app root, to keep the dpad-nav graph and focus HUD in sync with the DOM. */
+export function useDpadLifecycle(route: string) {
+  useLayoutEffect(() => {
+    refreshDpad();
+    focusInitial();
+  }, [route]);
+
+  useEffect(() => {
+    // DpadController.onKeyDown preventDefaults Enter/Space and routes to
+    // FocusableItem#onItemClickStateChange, which is a no-op unless you
+    // supply your own FocusableItem subclass -- so out of the box, a
+    // focused .dpad-focusable element does NOT activate on Enter the way
+    // native browser focus normally would. Restore that expectation
+    // generically: whatever's focused, click it.
+    const onKeyUp = (event: KeyboardEvent) => {
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      const el = document.activeElement;
+      if (el instanceof HTMLElement && el.classList.contains('dpad-focusable')) {
+        el.click();
+      }
+    };
+
+    const onFocus = (event: FocusEvent) => {
+      const el = event.target as HTMLElement;
+      if (!el.classList?.contains('dpad-focusable')) return;
+      const rect = el.getBoundingClientRect();
+      focusedNodeStore.set({
+        id: el.dataset.nodeId || el.tagName.toLowerCase(),
+        tabindex: el.tabIndex,
+        x: Math.round(rect.x),
+        y: Math.round(rect.y),
+      });
+
+      const rail = el.closest('.rail');
+      if (rail) {
+        const railRect = rail.getBoundingClientRect();
+        const elRect = el.getBoundingClientRect();
+        if (elRect.right > railRect.right - 80) {
+          rail.scrollBy({left: 320, behavior: 'smooth'});
+        } else if (elRect.left < railRect.left + 80) {
+          rail.scrollBy({left: -320, behavior: 'smooth'});
+        }
+      }
+    };
+
+    document.addEventListener('keyup', onKeyUp);
+    document.addEventListener('focus', onFocus, true);
+    return () => {
+      document.removeEventListener('keyup', onKeyUp);
+      document.removeEventListener('focus', onFocus, true);
+    };
+  }, []);
+}

--- a/examples/react/src/main.tsx
+++ b/examples/react/src/main.tsx
@@ -1,0 +1,10 @@
+import {StrictMode} from 'react';
+import {createRoot} from 'react-dom/client';
+import './app.css';
+import App from './App';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/react/src/pages/Grid.module.css
+++ b/examples/react/src/pages/Grid.module.css
@@ -1,0 +1,81 @@
+.pageHead {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 40px;
+}
+.pageHead h2 {
+  font-size: 40px;
+  margin: 0 0 8px;
+  color: var(--primary);
+}
+.pageHead p {
+  color: var(--on-surface-variant);
+  margin: 0;
+  max-width: 640px;
+}
+.debugToggleBtn {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 24px;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(90deg, #7b2ff7, #6f00be);
+  color: white;
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 700;
+  font-size: 14px;
+  cursor: pointer;
+}
+.labGrid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 24px;
+}
+.node {
+  border: 1px solid var(--outline-variant);
+  background: var(--surface-container);
+  border-radius: 12px;
+  padding: 20px;
+  display: flex;
+  align-items: flex-end;
+  min-height: 160px;
+  font-size: 20px;
+  font-weight: 700;
+  box-sizing: border-box;
+}
+.feature {
+  grid-column: span 3;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-end;
+  background: linear-gradient(135deg, #1b2a4a, #0b1326);
+}
+.feature p {
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--on-surface-variant);
+  margin: 8px 0 0;
+}
+.wide {
+  grid-column: span 2;
+  background: linear-gradient(135deg, #101d3d, #0b1326);
+}
+.footer {
+  grid-column: span 4;
+  background: linear-gradient(135deg, #0e1830, #0b1326);
+}
+.labStatus {
+  margin-top: 40px;
+  padding-top: 24px;
+  border-top: 1px solid var(--outline-variant);
+  display: flex;
+  gap: 48px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 14px;
+  color: var(--on-surface-variant);
+}
+.labStatus b {
+  color: var(--tertiary);
+}

--- a/examples/react/src/pages/Grid.tsx
+++ b/examples/react/src/pages/Grid.tsx
@@ -1,0 +1,80 @@
+import {toggleDebug, useDebugOn, useFocusedNode} from '../lib/dpad';
+import styles from './Grid.module.css';
+
+const simpleNodes = ['05', '06', '07', '08', '09'];
+
+export default function Grid() {
+  const debugOn = useDebugOn();
+  const focused = useFocusedNode();
+
+  return (
+    <>
+      <div className={styles.pageHead}>
+        <div>
+          <h2>Navigation Lab</h2>
+          <p>
+            Complex 5-column spatial traversal testing — irregular spans force the library's nearest-neighbor logic,
+            not simple grid-index math.
+          </p>
+        </div>
+        <button className={styles.debugToggleBtn} onClick={toggleDebug} data-node-id="debug-toggle">
+          <span className="material-symbols-outlined" style={{fontSize: 18}}>
+            bug_report
+          </span>
+          Debug Mode: {debugOn ? 'ON' : 'OFF'}
+        </button>
+      </div>
+
+      <div className={styles.labGrid}>
+        <div className={`dpad-focusable ${styles.node}`} role="button" tabIndex={0} data-node-id="node-01" data-dpad-initial-focus>
+          01
+        </div>
+        <div className={`dpad-focusable ${styles.node} ${styles.wide}`} role="button" tabIndex={0} data-node-id="node-02">
+          02 — Wide Node
+        </div>
+        <div className={`dpad-focusable ${styles.node}`} role="button" tabIndex={0} data-node-id="node-03">
+          03
+        </div>
+        <div className={`dpad-focusable ${styles.node}`} role="button" tabIndex={0} data-node-id="node-04">
+          04
+        </div>
+
+        {simpleNodes.map((n) => (
+          <div key={n} className={`dpad-focusable ${styles.node}`} role="button" tabIndex={0} data-node-id={`node-${n}`}>
+            {n}
+          </div>
+        ))}
+
+        <div className={`dpad-focusable ${styles.node} ${styles.feature}`} role="button" tabIndex={0} data-node-id="node-feature">
+          Feature Node — Path Test
+          <p>Spanning 3 columns forces unique up/down logic across the items above and below.</p>
+        </div>
+        <div className={`dpad-focusable ${styles.node}`} role="button" tabIndex={0} data-node-id="node-10">
+          10
+        </div>
+        <div className={`dpad-focusable ${styles.node}`} role="button" tabIndex={0} data-node-id="node-11">
+          11
+        </div>
+
+        <div className={`dpad-focusable ${styles.node}`} role="button" tabIndex={0} data-node-id="node-12">
+          12
+        </div>
+        <div className={`dpad-focusable ${styles.node} ${styles.footer}`} role="button" tabIndex={0} data-node-id="node-13">
+          13 — Massive Footer Node
+        </div>
+      </div>
+
+      <div className={styles.labStatus}>
+        <span>
+          Focus Count: <b>14 Nodes</b>
+        </span>
+        <span>
+          Grid Layout: <b>5-Column Responsive</b>
+        </span>
+        <span>
+          Current Pos: <b>{focused?.id ?? 'node-01'}</b>
+        </span>
+      </div>
+    </>
+  );
+}

--- a/examples/react/src/pages/Home.module.css
+++ b/examples/react/src/pages/Home.module.css
@@ -66,7 +66,15 @@
   display: flex;
   gap: 24px;
   overflow-x: auto;
-  padding: 8px 4px 16px;
+  /* The focused card scales up (transform: scale(1.05)) and grows a
+     25px glow (box-shadow); overflow-x: auto clips both at this
+     container's edge, so the first/last card looked clipped when
+     focused. Give the scroll box 40px of padding on every side as
+     breathing room, then pull it back with a matching negative
+     margin so the rail's resting-state alignment with its heading
+     above is unaffected. */
+  margin: 0 -40px;
+  padding: 24px 40px;
 }
 .card {
   flex: none;

--- a/examples/react/src/pages/Home.module.css
+++ b/examples/react/src/pages/Home.module.css
@@ -1,0 +1,91 @@
+.hero {
+  padding: 40px 0 80px;
+  max-width: 640px;
+}
+.eyebrow {
+  font-family: 'JetBrains Mono', monospace;
+  letter-spacing: 0.2em;
+  color: var(--secondary);
+  font-size: 14px;
+}
+.hero h2 {
+  font-size: 56px;
+  line-height: 1.1;
+  margin: 16px 0 24px;
+}
+.hero p {
+  color: var(--on-surface-variant);
+  font-size: 18px;
+  line-height: 1.6;
+  margin-bottom: 32px;
+}
+.heroActions {
+  display: flex;
+  gap: 20px;
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 16px 32px;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: inherit;
+}
+.btnPrimary {
+  background: var(--primary);
+  color: var(--on-primary);
+}
+.btnSecondary {
+  background: rgba(45, 52, 73, 0.6);
+  color: var(--on-surface);
+  border-color: var(--outline-variant);
+}
+.shelf {
+  margin-bottom: 56px;
+}
+.shelfHead {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 20px;
+}
+.shelfHead h3 {
+  font-size: 24px;
+  margin: 0;
+}
+.shelfHead span {
+  color: var(--secondary);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 14px;
+}
+.rail {
+  display: flex;
+  gap: 24px;
+  overflow-x: auto;
+  padding: 8px 4px 16px;
+}
+.card {
+  flex: none;
+  border-radius: 14px;
+  border: 2px solid transparent;
+  overflow: hidden;
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  padding: 16px;
+  font-weight: 700;
+  color: white;
+  box-sizing: border-box;
+}
+.wide {
+  width: 320px;
+  aspect-ratio: 16 / 9;
+}
+.tall {
+  width: 200px;
+  aspect-ratio: 2 / 3;
+}

--- a/examples/react/src/pages/Home.tsx
+++ b/examples/react/src/pages/Home.tsx
@@ -1,0 +1,90 @@
+import styles from './Home.module.css';
+
+const trending = [
+  {id: 'signal-lost', title: 'Signal Lost', gradient: 'linear-gradient(135deg, #1b2a4a, #0b1326)'},
+  {id: 'velocity-noir', title: 'Velocity Noir', gradient: 'linear-gradient(135deg, #3a1b4a, #0b1326)'},
+  {id: 'eden-404', title: 'Eden 404', gradient: 'linear-gradient(135deg, #0f4a3a, #0b1326)'},
+  {id: 'protocol-7', title: 'Protocol 7', gradient: 'linear-gradient(135deg, #4a1b2e, #0b1326)'},
+];
+
+const library = [
+  {id: 'orbital', title: 'Orbital', gradient: 'linear-gradient(160deg, #2a2450, #0b1326)'},
+  {id: 'synthesis', title: 'Synthesis', gradient: 'linear-gradient(160deg, #4a3a1b, #0b1326)'},
+  {id: 'retroglow', title: 'Retroglow', gradient: 'linear-gradient(160deg, #4a1b45, #0b1326)'},
+  {id: 'monolith', title: 'Monolith', gradient: 'linear-gradient(160deg, #33394a, #0b1326)'},
+  {id: 'flux', title: 'Flux', gradient: 'linear-gradient(160deg, #1b3a4a, #0b1326)'},
+];
+
+export default function Home() {
+  return (
+    <>
+      <section className={styles.hero}>
+        <div className={styles.eyebrow}>ORIGINAL SERIES</div>
+        <h2>
+          THE NEON
+          <br />
+          CHRONICLES
+        </h2>
+        <p>
+          In a world where memories are traded like currency, one rogue navigator must find the source code of
+          reality before the system reboots.
+        </p>
+        <div className={styles.heroActions}>
+          <button
+            className={`dpad-focusable ${styles.btn} ${styles.btnPrimary}`}
+            tabIndex={0}
+            data-node-id="play-now"
+            data-dpad-initial-focus
+          >
+            <span className="material-symbols-outlined">play_arrow</span>Play Now
+          </button>
+          <button className={`dpad-focusable ${styles.btn} ${styles.btnSecondary}`} tabIndex={0} data-node-id="more-info">
+            <span className="material-symbols-outlined">info</span>More Info
+          </button>
+        </div>
+      </section>
+
+      <section className={styles.shelf}>
+        <div className={styles.shelfHead}>
+          <h3>Trending Now</h3>
+          <span>View All</span>
+        </div>
+        <div className={`${styles.rail} rail no-scrollbar`}>
+          {trending.map((item) => (
+            <div
+              key={item.id}
+              className={`dpad-focusable ${styles.card} ${styles.wide}`}
+              role="button"
+              tabIndex={0}
+              data-node-id={item.id}
+              style={{background: item.gradient}}
+            >
+              {item.title}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.shelf}>
+        <div className={styles.shelfHead}>
+          <h3>Your Library</h3>
+          <span>Sort by Recent</span>
+        </div>
+        <div className={`${styles.rail} rail no-scrollbar`}>
+          {library.map((item) => (
+            <div
+              key={item.id}
+              className={`dpad-focusable ${styles.card} ${styles.tall}`}
+              role="button"
+              tabIndex={0}
+              data-node-id={item.id}
+              style={{background: item.gradient}}
+            >
+              {item.title}
+            </div>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/examples/react/src/pages/Lists.module.css
+++ b/examples/react/src/pages/Lists.module.css
@@ -1,0 +1,103 @@
+.listsShell {
+  display: flex;
+  gap: 56px;
+  align-items: flex-start;
+}
+.categories {
+  width: 260px;
+  flex: none;
+}
+.categories h4 {
+  font-family: 'JetBrains Mono', monospace;
+  letter-spacing: 0.15em;
+  font-size: 13px;
+  color: var(--on-surface-variant);
+  margin-bottom: 20px;
+}
+.listFocus {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 20px;
+  border-radius: 10px;
+  font-size: 16px;
+  background: transparent;
+  border: none;
+  color: var(--on-surface);
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  font-family: inherit;
+  box-sizing: border-box;
+}
+.contentCol {
+  flex: 1;
+  min-width: 0;
+}
+.contentCol h2 {
+  font-size: 32px;
+  margin: 0 0 8px;
+}
+.contentCol > p {
+  color: var(--on-surface-variant);
+  margin: 0 0 32px;
+}
+.mediaRow {
+  display: flex;
+  gap: 24px;
+  border-radius: 14px;
+  border: 1px solid var(--outline-variant);
+  background: var(--surface-container);
+  padding: 20px;
+  margin-bottom: 20px;
+  align-items: center;
+  box-sizing: border-box;
+}
+.thumb {
+  width: 220px;
+  height: 130px;
+  border-radius: 10px;
+  flex: none;
+}
+.body {
+  flex: 1;
+  min-width: 0;
+}
+.body h3 {
+  margin: 0 0 8px;
+  font-size: 24px;
+}
+.body p {
+  margin: 0 0 12px;
+  color: var(--on-surface-variant);
+  font-size: 15px;
+}
+.badge {
+  padding: 6px 16px;
+  border-radius: 999px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  font-weight: 700;
+  float: right;
+}
+.meta {
+  display: flex;
+  gap: 20px;
+  color: var(--secondary);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 14px;
+}
+.axisPanel {
+  margin-top: 32px;
+  padding: 20px;
+  border-radius: 10px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 14px;
+}
+.axisPanel .row {
+  margin: 6px 0;
+  color: var(--on-surface-variant);
+}
+.axisPanel b {
+  color: var(--secondary);
+}

--- a/examples/react/src/pages/Lists.tsx
+++ b/examples/react/src/pages/Lists.tsx
@@ -1,0 +1,110 @@
+import {useState} from 'react';
+import {useFocusedNode} from '../lib/dpad';
+import styles from './Lists.module.css';
+
+const categories = [
+  {id: 'cat-recommended', icon: 'auto_awesome', label: 'Recommended'},
+  {id: 'cat-originals', icon: 'movie', label: 'Cinema Originals'},
+  {id: 'cat-recent', icon: 'history', label: 'Recently Viewed'},
+  {id: 'cat-favorites', icon: 'favorite', label: 'My Favorites'},
+];
+
+const rows = [
+  {
+    id: 'row-neon-genesis',
+    title: 'Neon Genesis',
+    desc: 'A deep dive into the architecture of the 24th century.',
+    badge: 'ULTRA HD',
+    badgeBg: 'var(--primary)',
+    badgeFg: 'var(--on-primary)',
+    gradient: 'linear-gradient(135deg, #1b2a4a, #0b1326)',
+    rating: '4.9',
+    length: '2h 15m',
+  },
+  {
+    id: 'row-ethereal-peaks',
+    title: 'Ethereal Peaks',
+    desc: 'Escape to the highest altitudes of the world.',
+    badge: 'HDR10+',
+    badgeBg: 'var(--secondary)',
+    badgeFg: '#2c0051',
+    gradient: 'linear-gradient(135deg, #3a1b4a, #0b1326)',
+    rating: '4.8',
+    length: '1h 40m',
+  },
+  {
+    id: 'row-liquid-motion',
+    title: 'Liquid Motion',
+    desc: 'An abstract exploration of fluid dynamics.',
+    badge: 'SPATIAL AUDIO',
+    badgeBg: 'var(--tertiary)',
+    badgeFg: '#00363e',
+    gradient: 'linear-gradient(135deg, #0f4a3a, #0b1326)',
+    rating: '5.0',
+    length: '45m',
+  },
+];
+
+export default function Lists() {
+  const focused = useFocusedNode();
+  const [axisLock, setAxisLock] = useState<'VERTICAL' | 'HORIZONTAL'>('VERTICAL');
+
+  return (
+    <div className={styles.listsShell}>
+      <div className={styles.categories}>
+        <h4>CATEGORIES</h4>
+        {categories.map((cat, i) => (
+          <button
+            key={cat.id}
+            className={`dpad-focusable ${styles.listFocus} list-focus`}
+            tabIndex={0}
+            data-node-id={cat.id}
+            data-dpad-initial-focus={i === 0 ? true : undefined}
+            onFocus={() => setAxisLock('VERTICAL')}
+          >
+            <span className="material-symbols-outlined">{cat.icon}</span>
+            {cat.label}
+          </button>
+        ))}
+
+        <div className={`${styles.axisPanel} glass-panel mono`}>
+          <div className={styles.row}>
+            FOCUS_NODE_ID: <b>{focused?.id ?? 'cat-recommended'}</b>
+          </div>
+          <div className={styles.row}>
+            AXIS_LOCK: <b>{axisLock}</b>
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.contentCol}>
+        <h2>Cinematic Highlights</h2>
+        <p>Explore the latest high-fidelity spatial experiences curated for the 10-foot UI.</p>
+
+        {rows.map((row) => (
+          <div
+            key={row.id}
+            className={`dpad-focusable ${styles.mediaRow}`}
+            role="button"
+            tabIndex={0}
+            data-node-id={row.id}
+            onFocus={() => setAxisLock('HORIZONTAL')}
+          >
+            <div className={styles.thumb} style={{background: row.gradient}} />
+            <div className={styles.body}>
+              <span className={styles.badge} style={{background: row.badgeBg, color: row.badgeFg}}>
+                {row.badge}
+              </span>
+              <h3>{row.title}</h3>
+              <p>{row.desc}</p>
+              <div className={styles.meta}>
+                <span>★ {row.rating}</span>
+                <span>{row.length}</span>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/examples/react/src/pages/Settings.module.css
+++ b/examples/react/src/pages/Settings.module.css
@@ -1,0 +1,162 @@
+.settingsShell {
+  display: flex;
+  gap: 56px;
+  align-items: flex-start;
+}
+.settingsNav {
+  width: 240px;
+  flex: none;
+}
+.settingsNav h4 {
+  font-size: 18px;
+  color: var(--on-surface-variant);
+  margin: 0 0 20px;
+}
+.listFocus {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 16px 20px;
+  border-radius: 10px;
+  background: transparent;
+  border: none;
+  color: var(--on-surface);
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  font-size: 16px;
+  margin-bottom: 8px;
+  box-sizing: border-box;
+}
+.listFocusActive {
+  background: var(--surface-container-high);
+  border-left: 4px solid var(--primary);
+}
+.panels {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  max-width: 760px;
+}
+.panel {
+  background: var(--surface-container);
+  border: 1px solid var(--outline-variant);
+  border-radius: 14px;
+  padding: 28px;
+  box-sizing: border-box;
+}
+.panel h5 {
+  margin: 0 0 16px;
+  font-size: 16px;
+  font-weight: 600;
+}
+.panel p {
+  color: var(--on-surface-variant);
+  font-size: 15px;
+  line-height: 1.5;
+  margin: 0 0 16px;
+}
+.panelCols {
+  display: flex;
+  gap: 24px;
+}
+.panelCols .panel {
+  flex: 1;
+}
+.field {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--surface-container-high);
+  border-radius: 10px;
+  padding: 16px 20px;
+  border: 2px solid transparent;
+  box-sizing: border-box;
+}
+.hint {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--on-surface-variant);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+}
+.switch {
+  width: 46px;
+  height: 26px;
+  border-radius: 999px;
+  background: var(--surface-bright);
+  border: none;
+  position: relative;
+  cursor: pointer;
+}
+.switch::after {
+  content: '';
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  background: white;
+  top: 3px;
+  left: 3px;
+  transition: left 0.2s ease;
+}
+.switchOn {
+  background: var(--primary);
+}
+.switchOn::after {
+  left: 23px;
+}
+.checkboxRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 0;
+  cursor: pointer;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  font-size: 15px;
+  width: 100%;
+  text-align: left;
+}
+.checkboxBox {
+  width: 20px;
+  height: 20px;
+  flex: none;
+  border-radius: 4px;
+  border: 2px solid var(--outline);
+  position: relative;
+}
+.checkboxBoxChecked {
+  background: var(--primary);
+  border-color: var(--primary);
+}
+.checkboxBoxChecked::after {
+  content: '';
+  position: absolute;
+  left: 6px;
+  top: 2px;
+  width: 5px;
+  height: 10px;
+  border: solid var(--on-primary);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+.resetBtn {
+  align-self: center;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 18px 40px;
+  border-radius: 999px;
+  border: none;
+  background: var(--secondary);
+  color: #2c0051;
+  font-weight: 700;
+  font-size: 16px;
+  cursor: pointer;
+}

--- a/examples/react/src/pages/Settings.tsx
+++ b/examples/react/src/pages/Settings.tsx
@@ -1,0 +1,126 @@
+import {useState} from 'react';
+import {dpad, refreshDpad, toggleDebug, useDebugOn, useFocusedNode} from '../lib/dpad';
+import styles from './Settings.module.css';
+
+const navItems = [
+  {id: 'settings-display', icon: 'desktop_windows', label: 'Display'},
+  {id: 'settings-audio', icon: 'volume_up', label: 'Audio & Voice'},
+  {id: 'settings-network', icon: 'wifi', label: 'Network'},
+  {id: 'settings-privacy', icon: 'shield', label: 'Privacy'},
+];
+
+export default function Settings() {
+  const debugOn = useDebugOn();
+  const focused = useFocusedNode();
+  const [shaderOn, setShaderOn] = useState(true);
+  const [zSpaceDebug, setZSpaceDebug] = useState(false);
+
+  function resetFocusState() {
+    refreshDpad();
+    dpad.setCurrentFocusItem(0);
+  }
+
+  return (
+    <>
+      <div className={styles.settingsShell}>
+        <div className={styles.settingsNav}>
+          <h4>Settings</h4>
+          {navItems.map((item, i) => (
+            <button
+              key={item.id}
+              className={`dpad-focusable ${styles.listFocus} list-focus${i === 0 ? ` ${styles.listFocusActive}` : ''}`}
+              tabIndex={0}
+              data-node-id={item.id}
+              data-dpad-initial-focus={i === 0 ? true : undefined}
+            >
+              <span className="material-symbols-outlined">{item.icon}</span>
+              {item.label}
+            </button>
+          ))}
+        </div>
+
+        <div className={styles.panels}>
+          <div className={styles.panel}>
+            <h5>Device Identity</h5>
+            <div className={`${styles.field} dpad-focusable`} role="button" tabIndex={0} data-node-id="device-name">
+              <span>Spatial-Node-01</span>
+              <span className={styles.hint}>
+                <span className="material-symbols-outlined" style={{fontSize: 16}}>
+                  edit
+                </span>
+                Press OK to Edit
+              </span>
+            </div>
+            <p style={{marginTop: 16, marginBottom: 0}}>
+              The name displayed when broadcasting to other spatial nodes on your network.
+            </p>
+          </div>
+
+          <div className={styles.panelCols}>
+            <div className={styles.panel}>
+              <h5>Atmospheric Depth</h5>
+              <p>Enable background shaders and glassmorphism effects for a more immersive experience.</p>
+              <div className={styles.field}>
+                <span>Enable Shader Layer</span>
+                <button
+                  className={`dpad-focusable ${styles.switch}${shaderOn ? ` ${styles.switchOn}` : ''}`}
+                  tabIndex={0}
+                  data-node-id="shader-layer"
+                  role="switch"
+                  aria-label="Enable Shader Layer"
+                  aria-checked={shaderOn}
+                  onClick={() => setShaderOn((v) => !v)}
+                />
+              </div>
+            </div>
+            <div className={styles.panel}>
+              <h5>Telemetry Nodes</h5>
+              <button
+                type="button"
+                className={`dpad-focusable ${styles.checkboxRow}`}
+                tabIndex={0}
+                data-node-id="show-focus-vectors"
+                aria-pressed={debugOn}
+                onClick={toggleDebug}
+              >
+                <span className={`${styles.checkboxBox}${debugOn ? ` ${styles.checkboxBoxChecked}` : ''}`} aria-hidden="true" />
+                Show Focus Vectors
+              </button>
+              <button
+                type="button"
+                className={`dpad-focusable ${styles.checkboxRow}`}
+                tabIndex={0}
+                data-node-id="z-space-debugging"
+                aria-pressed={zSpaceDebug}
+                onClick={() => setZSpaceDebug((v) => !v)}
+              >
+                <span
+                  className={`${styles.checkboxBox}${zSpaceDebug ? ` ${styles.checkboxBoxChecked}` : ''}`}
+                  aria-hidden="true"
+                />
+                Z-Space Debugging
+              </button>
+            </div>
+          </div>
+
+          <button className={`dpad-focusable ${styles.resetBtn}`} tabIndex={0} data-node-id="reset-focus-state" onClick={resetFocusState}>
+            <span className="material-symbols-outlined">restart_alt</span>Reset Focus State
+          </button>
+        </div>
+      </div>
+
+      <div className="debug-hud glass-panel mono visible" style={{bottom: 32, right: 32}}>
+        <div>
+          <span className="dot" />
+          <b>SPATIAL DEBUGGER ACTIVE</b>
+        </div>
+        <div className="row">
+          Focus ID: <b>{focused?.id?.toUpperCase() ?? 'NONE'}</b>
+        </div>
+        <div className="row">
+          Traversal: <b>D-PAD_LIBRARY</b>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/examples/react/src/vite-env.d.ts
+++ b/examples/react/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/react/tsconfig.app.json
+++ b/examples/react/tsconfig.app.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/examples/react/tsconfig.json
+++ b/examples/react/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    {"path": "./tsconfig.app.json"},
+    {"path": "./tsconfig.node.json"}
+  ]
+}

--- a/examples/react/tsconfig.node.json
+++ b/examples/react/tsconfig.node.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/react/vite.config.ts
+++ b/examples/react/vite.config.ts
@@ -1,0 +1,6 @@
+import {defineConfig} from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- Adds `examples/react/`, the same four-screen `SpatialExplorer` demo as the static HTML (#64) and Svelte (#65) versions, as a React 19 + Vite + TypeScript SPA (hash-routed, no router dependency, CSS Modules for per-page styles), consuming `@gauntface/dpad-nav` as a real npm dependency (`file:../..`).
- `src/lib/dpad.ts` owns a single `DpadController`/`DebugController` pair for the app's lifetime, exposes `useDebugOn()`/`useFocusedNode()` as tiny `useSyncExternalStore`-backed stores, and `useDpadLifecycle(route)` calls `dpad.update()`/`focusInitial()` after each route's DOM commits.
- Carries forward both fixes discovered while building the other two demos: the Enter/Space-activates-the-focused-element bridge (`DpadController` preventDefaults Enter/Space and routes to a no-op hook instead of native button activation), and not stacking two debug-HUD panels on the settings page.
- **Caught one more, React-specific bug** while building this: the "Show Focus Vectors" button initially called `debugController.toggleDebugMode()` directly instead of the shared `toggleDebug()` helper, so it silently updated the library's debug state but never notified the store that `TopBar`/`Grid`/the button's own `aria-pressed` read from. Fixed and verified `false → true` via headless Chrome before pushing.

## Test plan
- [x] `tsc -b && vite build` — no type errors
- [x] Production build driven end-to-end with real headless Chrome + keyboard events across all four routes — identical navigation behavior to the static-html/Svelte versions, including the grid's irregular-span nearest-neighbor quirk (67 debug lines rendered)
- [x] Precisely verified: `aria-pressed` on "Show Focus Vectors" false→true on Enter; a real `<button>`-based switch toggles on Enter; exactly one `.debug-hud` panel renders on the settings page
- [x] No console/page/network errors besides the browser's own favicon.ico request