### PR TITLE
Restore Enter/Space click activation on FocusableItem

### DIFF
--- a/src/lib/_focusable-item.ts
+++ b/src/lib/_focusable-item.ts
@@ -111,7 +111,17 @@ export class FocusableItem {
   }
 
   onItemClickStateChange(isDown: boolean) {
-    // NOOP
+    // Mirrors native browser behavior for a focused, natively-interactive
+    // element: Enter/Space "clicks" it on release, not on press. This used
+    // to live only in a demo app's own FocusableItem subclass (see
+    // demos/demo1 in this repo's history, since removed) rather than the
+    // library itself, which meant every consumer had to rediscover and
+    // rebuild this bridge on their own. Restored here so it works by
+    // default; subclass FocusableItem and override this method if you need
+    // different press/release semantics.
+    if (!isDown) {
+      this.element.click();
+    }
   }
 }
 

--- a/src/lib/dpad-controller.ts
+++ b/src/lib/dpad-controller.ts
@@ -291,7 +291,7 @@ export class DpadController {
             break;
         case 13:
         case 32:
-            // Enter
+            // Enter / Space
             event.preventDefault();
             if(this.currentlyFocusedItem) {
                 this.currentlyFocusedItem.onItemClickStateChange(true);
@@ -303,7 +303,8 @@ export class DpadController {
   private onKeyUp(event: KeyboardEvent) {
     switch(event.keyCode) {
         case 13:
-            // Enter
+        case 32:
+            // Enter / Space
             event.preventDefault();
             if(this.currentlyFocusedItem) {
                 this.currentlyFocusedItem.onItemClickStateChange(false);


### PR DESCRIPTION
## Summary

`FocusableItem#onItemClickStateChange` has been a no-op since the TypeScript
rewrite (`2d37d12`/`bfd36fc`), so a focused `.dpad-focusable` element never
activates on Enter/Space the way native browser focus normally would —
`DpadController.onKeyDown` preventDefaults both keys and routes to this
hook instead of letting a native click fire.

This isn't a new limitation, it's a regression: `demos/demo1` (removed in
`24f1001`, predates the TS rewrite) had its own `GenericFocusableItem`
subclass whose `onItemClickStateChange` dispatched a real click on key
release (`c5ae100`, *"fire click event when using enter as well as include
the pressed state"*). That subclass never made it into the library itself,
and `findFocusableItems()` has no hook for injecting a custom
`FocusableItem`, so this got quietly lost and every consumer since has had
to rediscover and rebuild the bridge themselves (three `examples/` PRs in
this repo all independently hit it: #64, #65, #66).

- Restores it in the base `FocusableItem` using `HTMLElement.click()`
  (stricter than the original's manually-dispatched `MouseEvent`, since
  `.click()` also triggers native default actions — checkboxes toggle,
  links navigate, forms submit — not just JS listeners).
- Fixes a related asymmetry found along the way: Space support was added
  to `onKeyDown` in 2020 (`dfe5627`) but never mirrored into `onKeyUp`, so
  a Space *press* set pressed-state but its *release* never fired — only
  Enter's release did. Both keys now behave identically.

Subclassing `FocusableItem` and overriding `onItemClickStateChange` is
still the escape hatch for consumers who want different press/release
semantics (e.g. only-fire-on-long-press).

## Test plan
- [x] `npm run build` succeeds
- [x] Verified with headless Chrome against the built browser bundle:
  - Enter fires exactly one click; Space fires exactly one click; repeated
    presses don't double-fire
  - Directional (arrow-key) navigation is unaffected
  - Works for both a native `<button>` and a non-native
    `<div role="button">`, since this library explicitly supports
    tabindex'd non-native elements
- [ ] Note: this repo has no automated test suite on `master` currently
  (`npm run test` just runs the build) — happy to add one if useful, kept
  out of this PR to stay focused